### PR TITLE
feat: Step 3 단일 스레드 API 서버와 기본 HTTP 라우팅 추가

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ CFLAGS = -Wall -Wextra -std=c99 -g \
 	-Isrc/concurrency \
 	-Isrc/db \
 	-Isrc/common \
-	-Isrc/cli
+	-Isrc/cli \
+	-pthread
 DEPFLAGS = -MMD -MP
 SRC_DIR = src
 TEST_DIR = tests

--- a/src/api/api_main.c
+++ b/src/api/api_main.c
@@ -1,7 +1,52 @@
+#include "api_server.h"
+#include "db_engine_facade.h"
+#include "utils.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 
-int main(void) {
-    puts("api_server stub: HTTP server wiring will be added in Step 3.");
+static int api_main_parse_port(const char *text, int *out_port) {
+    long long parsed;
+
+    if (text == NULL || out_port == NULL || !utils_is_integer(text)) {
+        return FAILURE;
+    }
+
+    parsed = utils_parse_integer(text);
+    if (parsed <= 0 || parsed > 65535) {
+        return FAILURE;
+    }
+
+    *out_port = (int)parsed;
+    return SUCCESS;
+}
+
+int main(int argc, char *argv[]) {
+    DbEngine engine;
+    ApiServerConfig config;
+
+    config.port = 8080;
+
+    if (argc > 2) {
+        fprintf(stderr, "Usage: %s [port]\n", argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    if (argc == 2 && api_main_parse_port(argv[1], &config.port) != SUCCESS) {
+        fprintf(stderr, "Error: Invalid port '%s'.\n", argv[1]);
+        return EXIT_FAILURE;
+    }
+
+    if (db_engine_init(&engine) != SUCCESS) {
+        fprintf(stderr, "Error: Failed to initialize DB engine.\n");
+        return EXIT_FAILURE;
+    }
+
+    if (api_server_run(&engine, &config) != SUCCESS) {
+        db_engine_shutdown(&engine);
+        return EXIT_FAILURE;
+    }
+
+    db_engine_shutdown(&engine);
     return EXIT_SUCCESS;
 }

--- a/src/api/api_main.c
+++ b/src/api/api_main.c
@@ -5,19 +5,19 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-static int api_main_parse_port(const char *text, int *out_port) {
+static int api_main_parse_positive_int(const char *text, int max_value, int *out_value) {
     long long parsed;
 
-    if (text == NULL || out_port == NULL || !utils_is_integer(text)) {
+    if (text == NULL || out_value == NULL || !utils_is_integer(text)) {
         return FAILURE;
     }
 
     parsed = utils_parse_integer(text);
-    if (parsed <= 0 || parsed > 65535) {
+    if (parsed <= 0 || parsed > max_value) {
         return FAILURE;
     }
 
-    *out_port = (int)parsed;
+    *out_value = (int)parsed;
     return SUCCESS;
 }
 
@@ -26,14 +26,28 @@ int main(int argc, char *argv[]) {
     ApiServerConfig config;
 
     config.port = 8080;
+    config.worker_count = 4;
+    config.queue_capacity = 16;
 
-    if (argc > 2) {
-        fprintf(stderr, "Usage: %s [port]\n", argv[0]);
+    if (argc > 4) {
+        fprintf(stderr, "Usage: %s [port] [worker_count] [queue_capacity]\n", argv[0]);
         return EXIT_FAILURE;
     }
 
-    if (argc == 2 && api_main_parse_port(argv[1], &config.port) != SUCCESS) {
+    if (argc >= 2 && api_main_parse_positive_int(argv[1], 65535, &config.port) != SUCCESS) {
         fprintf(stderr, "Error: Invalid port '%s'.\n", argv[1]);
+        return EXIT_FAILURE;
+    }
+
+    if (argc >= 3 &&
+        api_main_parse_positive_int(argv[2], 256, &config.worker_count) != SUCCESS) {
+        fprintf(stderr, "Error: Invalid worker count '%s'.\n", argv[2]);
+        return EXIT_FAILURE;
+    }
+
+    if (argc >= 4 &&
+        api_main_parse_positive_int(argv[3], 4096, &config.queue_capacity) != SUCCESS) {
+        fprintf(stderr, "Error: Invalid queue capacity '%s'.\n", argv[3]);
         return EXIT_FAILURE;
     }
 

--- a/src/api/api_server.c
+++ b/src/api/api_server.c
@@ -1,0 +1,330 @@
+#include "api_server.h"
+
+#include "http_parser.h"
+#include "request_router.h"
+#include "response_builder.h"
+#include "utils.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <strings.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#define API_SERVER_READ_CHUNK 4096
+#define API_SERVER_MAX_REQUEST_SIZE 65536
+
+static int api_server_append_bytes(char **buffer, size_t *length, size_t *capacity,
+                                   const char *chunk, size_t chunk_length) {
+    char *new_buffer;
+    size_t new_capacity;
+
+    if (buffer == NULL || length == NULL || capacity == NULL ||
+        chunk == NULL || chunk_length == 0) {
+        return FAILURE;
+    }
+
+    if (*buffer == NULL) {
+        new_capacity = chunk_length + 1;
+        if (new_capacity < 1024) {
+            new_capacity = 1024;
+        }
+        *buffer = (char *)malloc(new_capacity);
+        if (*buffer == NULL) {
+            return FAILURE;
+        }
+        *length = 0;
+        *capacity = new_capacity;
+    } else if (*length + chunk_length + 1 > *capacity) {
+        new_capacity = *capacity;
+        while (*length + chunk_length + 1 > new_capacity) {
+            new_capacity *= 2;
+        }
+        new_buffer = (char *)realloc(*buffer, new_capacity);
+        if (new_buffer == NULL) {
+            return FAILURE;
+        }
+        *buffer = new_buffer;
+        *capacity = new_capacity;
+    }
+
+    memcpy(*buffer + *length, chunk, chunk_length);
+    *length += chunk_length;
+    (*buffer)[*length] = '\0';
+    return SUCCESS;
+}
+
+static int api_server_extract_content_length(const char *headers, size_t *out_length) {
+    const char *cursor;
+
+    if (headers == NULL || out_length == NULL) {
+        return FAILURE;
+    }
+
+    *out_length = 0;
+    cursor = headers;
+    while (*cursor != '\0') {
+        const char *line_end;
+
+        line_end = strstr(cursor, "\r\n");
+        if (line_end == NULL) {
+            break;
+        }
+
+        if (line_end == cursor) {
+            return SUCCESS;
+        }
+
+        if (strncasecmp(cursor, "Content-Length:", 15) == 0) {
+            cursor += 15;
+            while (*cursor == ' ' || *cursor == '\t') {
+                cursor++;
+            }
+            *out_length = (size_t)strtoull(cursor, NULL, 10);
+            return SUCCESS;
+        }
+
+        cursor = line_end + 2;
+    }
+
+    return SUCCESS;
+}
+
+static int api_server_read_http_request(int client_fd, char **out_raw_request) {
+    char chunk[API_SERVER_READ_CHUNK];
+    char *buffer;
+    size_t length;
+    size_t capacity;
+    size_t expected_total;
+    int header_complete;
+
+    if (out_raw_request == NULL) {
+        return FAILURE;
+    }
+
+    *out_raw_request = NULL;
+    buffer = NULL;
+    length = 0;
+    capacity = 0;
+    expected_total = 0;
+    header_complete = 0;
+
+    while (1) {
+        ssize_t bytes_read;
+        char *header_end;
+        size_t content_length;
+
+        bytes_read = recv(client_fd, chunk, sizeof(chunk), 0);
+        if (bytes_read < 0) {
+            free(buffer);
+            return FAILURE;
+        }
+        if (bytes_read == 0) {
+            break;
+        }
+
+        if (length + (size_t)bytes_read > API_SERVER_MAX_REQUEST_SIZE) {
+            free(buffer);
+            return FAILURE;
+        }
+
+        if (api_server_append_bytes(&buffer, &length, &capacity,
+                                    chunk, (size_t)bytes_read) != SUCCESS) {
+            free(buffer);
+            return FAILURE;
+        }
+
+        if (!header_complete) {
+            header_end = strstr(buffer, "\r\n\r\n");
+            if (header_end != NULL) {
+                header_complete = 1;
+                content_length = 0;
+                if (api_server_extract_content_length(buffer, &content_length) != SUCCESS) {
+                    free(buffer);
+                    return FAILURE;
+                }
+                expected_total = (size_t)(header_end - buffer) + 4 + content_length;
+            }
+        }
+
+        if (header_complete && length >= expected_total) {
+            break;
+        }
+    }
+
+    if (!header_complete) {
+        free(buffer);
+        return FAILURE;
+    }
+
+    *out_raw_request = buffer;
+    return SUCCESS;
+}
+
+static int api_server_send_all(int client_fd, const char *response) {
+    size_t total_sent;
+    size_t response_length;
+
+    if (response == NULL) {
+        return FAILURE;
+    }
+
+    total_sent = 0;
+    response_length = strlen(response);
+    while (total_sent < response_length) {
+        ssize_t sent;
+
+        sent = send(client_fd, response + total_sent,
+                    response_length - total_sent, 0);
+        if (sent <= 0) {
+            return FAILURE;
+        }
+        total_sent += (size_t)sent;
+    }
+
+    return SUCCESS;
+}
+
+static int api_server_send_json_error(int client_fd, int status_code,
+                                      const char *message) {
+    char *body;
+    char *response;
+    int status;
+
+    body = NULL;
+    response = NULL;
+
+    if (build_json_error_response(status_code, message, &body) != SUCCESS) {
+        return FAILURE;
+    }
+
+    status = build_http_response(status_code, body, &response);
+    free(body);
+    if (status != SUCCESS) {
+        return FAILURE;
+    }
+
+    status = api_server_send_all(client_fd, response);
+    free(response);
+    return status;
+}
+
+static int api_server_handle_client(int client_fd, DbEngine *engine) {
+    char *raw_request;
+    HttpRequest request;
+    char *body;
+    char *response;
+    int status_code;
+    int status;
+
+    raw_request = NULL;
+    body = NULL;
+    response = NULL;
+    memset(&request, 0, sizeof(request));
+
+    if (api_server_read_http_request(client_fd, &raw_request) != SUCCESS) {
+        return api_server_send_json_error(client_fd, 400, "Failed to read HTTP request.");
+    }
+
+    if (parse_http_request(raw_request, &request) != SUCCESS) {
+        free(raw_request);
+        return api_server_send_json_error(client_fd, 400, "Malformed HTTP request.");
+    }
+    free(raw_request);
+
+    status = route_request(engine, &request, &status_code, &body);
+    http_request_free(&request);
+    if (status != SUCCESS) {
+        free(body);
+        return api_server_send_json_error(client_fd, 500, "Failed to build response.");
+    }
+
+    status = build_http_response(status_code, body, &response);
+    free(body);
+    if (status != SUCCESS) {
+        free(response);
+        return api_server_send_json_error(client_fd, 500, "Failed to serialize HTTP response.");
+    }
+
+    status = api_server_send_all(client_fd, response);
+    free(response);
+    return status;
+}
+
+static int api_server_create_socket(int port) {
+    int server_fd;
+    int reuse_addr;
+    struct sockaddr_in address;
+
+    server_fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (server_fd < 0) {
+        return FAILURE;
+    }
+
+    reuse_addr = 1;
+    if (setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR,
+                   &reuse_addr, sizeof(reuse_addr)) != 0) {
+        close(server_fd);
+        return FAILURE;
+    }
+
+    memset(&address, 0, sizeof(address));
+    address.sin_family = AF_INET;
+    address.sin_addr.s_addr = htonl(INADDR_ANY);
+    address.sin_port = htons((uint16_t)port);
+
+    if (bind(server_fd, (struct sockaddr *)&address, sizeof(address)) != 0) {
+        close(server_fd);
+        return FAILURE;
+    }
+
+    if (listen(server_fd, 16) != 0) {
+        close(server_fd);
+        return FAILURE;
+    }
+
+    return server_fd;
+}
+
+int api_server_run(DbEngine *engine, const ApiServerConfig *config) {
+    int server_fd;
+
+    if (engine == NULL || config == NULL || config->port <= 0) {
+        return FAILURE;
+    }
+
+    server_fd = api_server_create_socket(config->port);
+    if (server_fd == FAILURE) {
+        fprintf(stderr, "Error: Failed to start API server on port %d: %s\n",
+                config->port, strerror(errno));
+        return FAILURE;
+    }
+
+    printf("API server listening on port %d\n", config->port);
+    fflush(stdout);
+
+    while (1) {
+        int client_fd;
+
+        client_fd = accept(server_fd, NULL, NULL);
+        if (client_fd < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            close(server_fd);
+            return FAILURE;
+        }
+
+        api_server_handle_client(client_fd, engine);
+        close(client_fd);
+    }
+
+    close(server_fd);
+    return SUCCESS;
+}

--- a/src/api/api_server.c
+++ b/src/api/api_server.c
@@ -1,5 +1,6 @@
 #include "api_server.h"
 
+#include "thread_pool.h"
 #include "http_parser.h"
 #include "request_router.h"
 #include "response_builder.h"
@@ -257,6 +258,14 @@ static int api_server_handle_client(int client_fd, DbEngine *engine) {
     return status;
 }
 
+static void api_server_worker_handle_client(int client_fd, void *context) {
+    DbEngine *engine;
+
+    engine = (DbEngine *)context;
+    api_server_handle_client(client_fd, engine);
+    close(client_fd);
+}
+
 static int api_server_create_socket(int port) {
     int server_fd;
     int reuse_addr;
@@ -294,8 +303,10 @@ static int api_server_create_socket(int port) {
 
 int api_server_run(DbEngine *engine, const ApiServerConfig *config) {
     int server_fd;
+    ThreadPool pool;
 
-    if (engine == NULL || config == NULL || config->port <= 0) {
+    if (engine == NULL || config == NULL || config->port <= 0 ||
+        config->worker_count <= 0 || config->queue_capacity <= 0) {
         return FAILURE;
     }
 
@@ -309,6 +320,13 @@ int api_server_run(DbEngine *engine, const ApiServerConfig *config) {
     printf("API server listening on port %d\n", config->port);
     fflush(stdout);
 
+    if (thread_pool_init(&pool, config->worker_count, config->queue_capacity,
+                         api_server_worker_handle_client, engine) != SUCCESS) {
+        close(server_fd);
+        fprintf(stderr, "Error: Failed to initialize thread pool.\n");
+        return FAILURE;
+    }
+
     while (1) {
         int client_fd;
 
@@ -318,13 +336,17 @@ int api_server_run(DbEngine *engine, const ApiServerConfig *config) {
                 continue;
             }
             close(server_fd);
+            thread_pool_shutdown(&pool);
             return FAILURE;
         }
 
-        api_server_handle_client(client_fd, engine);
-        close(client_fd);
+        if (thread_pool_submit(&pool, client_fd) != SUCCESS) {
+            api_server_send_json_error(client_fd, 503, "Server is busy.");
+            close(client_fd);
+        }
     }
 
     close(server_fd);
+    thread_pool_shutdown(&pool);
     return SUCCESS;
 }

--- a/src/api/api_server.h
+++ b/src/api/api_server.h
@@ -1,0 +1,15 @@
+#ifndef API_SERVER_H
+#define API_SERVER_H
+
+#include "db_engine_facade.h"
+
+typedef struct {
+    int port;
+} ApiServerConfig;
+
+/*
+ * 단일 스레드 API 서버를 시작하고 종료될 때까지 요청을 처리한다.
+ */
+int api_server_run(DbEngine *engine, const ApiServerConfig *config);
+
+#endif

--- a/src/api/api_server.h
+++ b/src/api/api_server.h
@@ -5,6 +5,8 @@
 
 typedef struct {
     int port;
+    int worker_count;
+    int queue_capacity;
 } ApiServerConfig;
 
 /*

--- a/src/api/http_parser.c
+++ b/src/api/http_parser.c
@@ -1,0 +1,64 @@
+#include "http_parser.h"
+
+#include "utils.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int parse_http_request(const char *raw_request, HttpRequest *out_request) {
+    const char *line_end;
+    const char *body_start;
+    char request_line[256];
+    size_t line_length;
+
+    if (raw_request == NULL || out_request == NULL) {
+        return FAILURE;
+    }
+
+    memset(out_request, 0, sizeof(*out_request));
+
+    line_end = strstr(raw_request, "\r\n");
+    if (line_end == NULL) {
+        return FAILURE;
+    }
+
+    line_length = (size_t)(line_end - raw_request);
+    if (line_length == 0 || line_length >= sizeof(request_line)) {
+        return FAILURE;
+    }
+
+    memcpy(request_line, raw_request, line_length);
+    request_line[line_length] = '\0';
+
+    if (sscanf(request_line, "%7s %127s %15s",
+               out_request->method,
+               out_request->path,
+               out_request->protocol) != 3) {
+        return FAILURE;
+    }
+
+    body_start = strstr(raw_request, "\r\n\r\n");
+    if (body_start == NULL) {
+        return FAILURE;
+    }
+
+    body_start += 4;
+    out_request->body_length = strlen(body_start);
+    out_request->body = utils_strdup(body_start);
+    if (out_request->body == NULL) {
+        return FAILURE;
+    }
+
+    return SUCCESS;
+}
+
+void http_request_free(HttpRequest *request) {
+    if (request == NULL) {
+        return;
+    }
+
+    free(request->body);
+    request->body = NULL;
+    request->body_length = 0;
+}

--- a/src/api/http_parser.h
+++ b/src/api/http_parser.h
@@ -1,0 +1,28 @@
+#ifndef HTTP_PARSER_H
+#define HTTP_PARSER_H
+
+#include <stddef.h>
+
+#define MAX_HTTP_METHOD_LEN 8
+#define MAX_HTTP_PATH_LEN 128
+#define MAX_HTTP_PROTOCOL_LEN 16
+
+typedef struct {
+    char method[MAX_HTTP_METHOD_LEN];
+    char path[MAX_HTTP_PATH_LEN];
+    char protocol[MAX_HTTP_PROTOCOL_LEN];
+    char *body;
+    size_t body_length;
+} HttpRequest;
+
+/*
+ * raw HTTP 요청을 구조화된 HttpRequest로 파싱한다.
+ */
+int parse_http_request(const char *raw_request, HttpRequest *out_request);
+
+/*
+ * HttpRequest가 소유한 동적 메모리를 해제한다.
+ */
+void http_request_free(HttpRequest *request);
+
+#endif

--- a/src/api/request_router.c
+++ b/src/api/request_router.c
@@ -1,0 +1,204 @@
+#include "request_router.h"
+
+#include "response_builder.h"
+#include "utils.h"
+
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char *request_router_skip_spaces(const char *cursor) {
+    while (cursor != NULL && *cursor != '\0' && isspace((unsigned char)*cursor)) {
+        cursor++;
+    }
+    return cursor;
+}
+
+static int request_router_append_json_char(char **buffer, size_t *length,
+                                           size_t *capacity, char value) {
+    char chunk[2];
+
+    chunk[0] = value;
+    chunk[1] = '\0';
+    return utils_append_buffer(buffer, length, capacity, chunk);
+}
+
+static int extract_sql_from_json(const char *body, char **out_sql) {
+    const char *cursor;
+    char *sql;
+    size_t length;
+    size_t capacity;
+
+    if (body == NULL || out_sql == NULL) {
+        return FAILURE;
+    }
+
+    cursor = strstr(body, "\"sql\"");
+    if (cursor == NULL) {
+        return FAILURE;
+    }
+
+    cursor += 5;
+    cursor = request_router_skip_spaces(cursor);
+    if (cursor == NULL || *cursor != ':') {
+        return FAILURE;
+    }
+
+    cursor++;
+    cursor = request_router_skip_spaces(cursor);
+    if (cursor == NULL || *cursor != '"') {
+        return FAILURE;
+    }
+
+    cursor++;
+    sql = NULL;
+    length = 0;
+    capacity = 0;
+
+    while (*cursor != '\0') {
+        if (*cursor == '"') {
+            *out_sql = sql;
+            return SUCCESS;
+        }
+
+        if (*cursor == '\\') {
+            cursor++;
+            if (*cursor == '\0') {
+                free(sql);
+                return FAILURE;
+            }
+
+            switch (*cursor) {
+                case '"':
+                case '\\':
+                case '/':
+                    if (request_router_append_json_char(&sql, &length, &capacity, *cursor) != SUCCESS) {
+                        free(sql);
+                        return FAILURE;
+                    }
+                    break;
+                case 'n':
+                    if (request_router_append_json_char(&sql, &length, &capacity, '\n') != SUCCESS) {
+                        free(sql);
+                        return FAILURE;
+                    }
+                    break;
+                case 'r':
+                    if (request_router_append_json_char(&sql, &length, &capacity, '\r') != SUCCESS) {
+                        free(sql);
+                        return FAILURE;
+                    }
+                    break;
+                case 't':
+                    if (request_router_append_json_char(&sql, &length, &capacity, '\t') != SUCCESS) {
+                        free(sql);
+                        return FAILURE;
+                    }
+                    break;
+                default:
+                    free(sql);
+                    return FAILURE;
+            }
+            cursor++;
+            continue;
+        }
+
+        if (request_router_append_json_char(&sql, &length, &capacity, *cursor) != SUCCESS) {
+            free(sql);
+            return FAILURE;
+        }
+        cursor++;
+    }
+
+    free(sql);
+    return FAILURE;
+}
+
+static int handle_health_request(int *out_status_code, char **out_body) {
+    if (build_health_json_response(out_body) != SUCCESS) {
+        return FAILURE;
+    }
+
+    *out_status_code = 200;
+    return SUCCESS;
+}
+
+static int handle_query_request(DbEngine *engine, const HttpRequest *request,
+                                int *out_status_code, char **out_body) {
+    DbResult result;
+    char *sql;
+    int status;
+
+    if (engine == NULL || request == NULL || out_status_code == NULL ||
+        out_body == NULL) {
+        return FAILURE;
+    }
+
+    sql = NULL;
+    if (extract_sql_from_json(request->body, &sql) != SUCCESS) {
+        *out_status_code = 400;
+        return build_json_error_response(400,
+                                         "Request body must contain a JSON string field named sql.",
+                                         out_body);
+    }
+
+    db_result_init(&result);
+    status = execute_query_with_lock(engine, sql, &result);
+    free(sql);
+
+    if (status != SUCCESS) {
+        if (build_json_error_response(400,
+                                      result.message[0] != '\0' ? result.message : "SQL execution failed.",
+                                      out_body) != SUCCESS) {
+            db_result_free(&result);
+            return FAILURE;
+        }
+        *out_status_code = 400;
+        db_result_free(&result);
+        return SUCCESS;
+    }
+
+    status = build_query_json_response(&result, out_status_code, out_body);
+    db_result_free(&result);
+    return status;
+}
+
+int route_request(DbEngine *engine, const HttpRequest *request,
+                  int *out_status_code, char **out_body) {
+    if (engine == NULL || request == NULL || out_status_code == NULL ||
+        out_body == NULL) {
+        return FAILURE;
+    }
+
+    *out_body = NULL;
+
+    if (utils_equals_ignore_case(request->path, "/health")) {
+        if (!utils_equals_ignore_case(request->method, "GET")) {
+            if (build_json_error_response(405, "Only GET is allowed for /health.",
+                                          out_body) != SUCCESS) {
+                return FAILURE;
+            }
+            *out_status_code = 405;
+            return SUCCESS;
+        }
+        return handle_health_request(out_status_code, out_body);
+    }
+
+    if (utils_equals_ignore_case(request->path, "/query")) {
+        if (!utils_equals_ignore_case(request->method, "POST")) {
+            if (build_json_error_response(405, "Only POST is allowed for /query.",
+                                          out_body) != SUCCESS) {
+                return FAILURE;
+            }
+            *out_status_code = 405;
+            return SUCCESS;
+        }
+        return handle_query_request(engine, request, out_status_code, out_body);
+    }
+
+    if (build_json_error_response(404, "Route not found.", out_body) != SUCCESS) {
+        return FAILURE;
+    }
+    *out_status_code = 404;
+    return SUCCESS;
+}

--- a/src/api/request_router.h
+++ b/src/api/request_router.h
@@ -1,0 +1,13 @@
+#ifndef REQUEST_ROUTER_H
+#define REQUEST_ROUTER_H
+
+#include "db_engine_facade.h"
+#include "http_parser.h"
+
+/*
+ * 메서드와 경로 기준으로 요청을 처리하고 JSON body와 상태 코드를 반환한다.
+ */
+int route_request(DbEngine *engine, const HttpRequest *request,
+                  int *out_status_code, char **out_body);
+
+#endif

--- a/src/api/response_builder.c
+++ b/src/api/response_builder.c
@@ -1,0 +1,268 @@
+#include "response_builder.h"
+
+#include "utils.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int response_builder_append_char(char **buffer, size_t *length,
+                                        size_t *capacity, char value) {
+    char chunk[2];
+
+    chunk[0] = value;
+    chunk[1] = '\0';
+    return utils_append_buffer(buffer, length, capacity, chunk);
+}
+
+static int response_builder_append_json_string(char **buffer, size_t *length,
+                                               size_t *capacity,
+                                               const char *text) {
+    size_t i;
+
+    if (response_builder_append_char(buffer, length, capacity, '"') != SUCCESS) {
+        return FAILURE;
+    }
+
+    if (text != NULL) {
+        for (i = 0; text[i] != '\0'; i++) {
+            switch (text[i]) {
+                case '\\':
+                    if (utils_append_buffer(buffer, length, capacity, "\\\\") != SUCCESS) {
+                        return FAILURE;
+                    }
+                    break;
+                case '"':
+                    if (utils_append_buffer(buffer, length, capacity, "\\\"") != SUCCESS) {
+                        return FAILURE;
+                    }
+                    break;
+                case '\n':
+                    if (utils_append_buffer(buffer, length, capacity, "\\n") != SUCCESS) {
+                        return FAILURE;
+                    }
+                    break;
+                case '\r':
+                    if (utils_append_buffer(buffer, length, capacity, "\\r") != SUCCESS) {
+                        return FAILURE;
+                    }
+                    break;
+                case '\t':
+                    if (utils_append_buffer(buffer, length, capacity, "\\t") != SUCCESS) {
+                        return FAILURE;
+                    }
+                    break;
+                default:
+                    if (response_builder_append_char(buffer, length, capacity, text[i]) != SUCCESS) {
+                        return FAILURE;
+                    }
+                    break;
+            }
+        }
+    }
+
+    return response_builder_append_char(buffer, length, capacity, '"');
+}
+
+static const char *response_builder_result_type_name(DbResultType type) {
+    switch (type) {
+        case DB_RESULT_INSERT:
+            return "insert";
+        case DB_RESULT_SELECT:
+            return "select";
+        case DB_RESULT_DELETE:
+            return "delete";
+        default:
+            return "unknown";
+    }
+}
+
+static const char *response_builder_status_text(int status_code) {
+    switch (status_code) {
+        case 200:
+            return "OK";
+        case 400:
+            return "Bad Request";
+        case 404:
+            return "Not Found";
+        case 405:
+            return "Method Not Allowed";
+        default:
+            return "Internal Server Error";
+    }
+}
+
+int build_query_json_response(const DbResult *result, int *out_status_code,
+                              char **out_body) {
+    char *buffer;
+    size_t length;
+    size_t capacity;
+    int i;
+    int j;
+    char number_buffer[64];
+
+    if (result == NULL || out_status_code == NULL || out_body == NULL) {
+        return FAILURE;
+    }
+
+    buffer = NULL;
+    length = 0;
+    capacity = 0;
+
+    if (utils_append_buffer(&buffer, &length, &capacity, "{\"ok\":true,\"type\":") != SUCCESS ||
+        response_builder_append_json_string(&buffer, &length, &capacity,
+                                            response_builder_result_type_name(result->type)) != SUCCESS ||
+        utils_append_buffer(&buffer, &length, &capacity, ",\"message\":") != SUCCESS ||
+        response_builder_append_json_string(&buffer, &length, &capacity, result->message) != SUCCESS) {
+        free(buffer);
+        return FAILURE;
+    }
+
+    if (result->type == DB_RESULT_INSERT) {
+        snprintf(number_buffer, sizeof(number_buffer), ",\"rows_affected\":%d}",
+                 result->rows_affected);
+        if (utils_append_buffer(&buffer, &length, &capacity, number_buffer) != SUCCESS) {
+            free(buffer);
+            return FAILURE;
+        }
+    } else if (result->type == DB_RESULT_SELECT) {
+        snprintf(number_buffer, sizeof(number_buffer),
+                 ",\"used_id_index\":%s,\"row_count\":%d,\"columns\":[",
+                 result->used_id_index ? "true" : "false", result->row_count);
+        if (utils_append_buffer(&buffer, &length, &capacity, number_buffer) != SUCCESS) {
+            free(buffer);
+            return FAILURE;
+        }
+
+        for (i = 0; i < result->column_count; i++) {
+            if (i > 0 &&
+                response_builder_append_char(&buffer, &length, &capacity, ',') != SUCCESS) {
+                free(buffer);
+                return FAILURE;
+            }
+            if (response_builder_append_json_string(&buffer, &length, &capacity,
+                                                    result->columns[i]) != SUCCESS) {
+                free(buffer);
+                return FAILURE;
+            }
+        }
+
+        if (utils_append_buffer(&buffer, &length, &capacity, "],\"rows\":[") != SUCCESS) {
+            free(buffer);
+            return FAILURE;
+        }
+
+        for (i = 0; i < result->row_count; i++) {
+            if (i > 0 &&
+                response_builder_append_char(&buffer, &length, &capacity, ',') != SUCCESS) {
+                free(buffer);
+                return FAILURE;
+            }
+            if (response_builder_append_char(&buffer, &length, &capacity, '[') != SUCCESS) {
+                free(buffer);
+                return FAILURE;
+            }
+            for (j = 0; j < result->column_count; j++) {
+                if (j > 0 &&
+                    response_builder_append_char(&buffer, &length, &capacity, ',') != SUCCESS) {
+                    free(buffer);
+                    return FAILURE;
+                }
+                if (response_builder_append_json_string(&buffer, &length, &capacity,
+                                                        result->rows[i][j]) != SUCCESS) {
+                    free(buffer);
+                    return FAILURE;
+                }
+            }
+            if (response_builder_append_char(&buffer, &length, &capacity, ']') != SUCCESS) {
+                free(buffer);
+                return FAILURE;
+            }
+        }
+
+        if (response_builder_append_char(&buffer, &length, &capacity, '}') != SUCCESS) {
+            free(buffer);
+            return FAILURE;
+        }
+    } else {
+        if (response_builder_append_char(&buffer, &length, &capacity, '}') != SUCCESS) {
+            free(buffer);
+            return FAILURE;
+        }
+    }
+
+    *out_status_code = 200;
+    *out_body = buffer;
+    return SUCCESS;
+}
+
+int build_json_error_response(int status_code, const char *message, char **out_body) {
+    char *buffer;
+    size_t length;
+    size_t capacity;
+    char number_buffer[64];
+
+    if (out_body == NULL) {
+        return FAILURE;
+    }
+
+    buffer = NULL;
+    length = 0;
+    capacity = 0;
+
+    snprintf(number_buffer, sizeof(number_buffer), "{\"ok\":false,\"status\":%d,\"error\":",
+             status_code);
+    if (utils_append_buffer(&buffer, &length, &capacity, number_buffer) != SUCCESS ||
+        response_builder_append_json_string(&buffer, &length, &capacity, message) != SUCCESS ||
+        response_builder_append_char(&buffer, &length, &capacity, '}') != SUCCESS) {
+        free(buffer);
+        return FAILURE;
+    }
+
+    *out_body = buffer;
+    return SUCCESS;
+}
+
+int build_health_json_response(char **out_body) {
+    if (out_body == NULL) {
+        return FAILURE;
+    }
+
+    *out_body = utils_strdup("{\"status\":\"ok\"}");
+    return *out_body == NULL ? FAILURE : SUCCESS;
+}
+
+int build_http_response(int status_code, const char *body, char **out_response) {
+    const char *status_text;
+    int written;
+    size_t body_length;
+    size_t response_size;
+
+    if (body == NULL || out_response == NULL) {
+        return FAILURE;
+    }
+
+    status_text = response_builder_status_text(status_code);
+    body_length = strlen(body);
+    response_size = body_length + 256;
+    *out_response = (char *)malloc(response_size);
+    if (*out_response == NULL) {
+        return FAILURE;
+    }
+
+    written = snprintf(*out_response, response_size,
+                       "HTTP/1.1 %d %s\r\n"
+                       "Content-Type: application/json\r\n"
+                       "Content-Length: %zu\r\n"
+                       "Connection: close\r\n"
+                       "\r\n"
+                       "%s",
+                       status_code, status_text, body_length, body);
+    if (written < 0 || (size_t)written >= response_size) {
+        free(*out_response);
+        *out_response = NULL;
+        return FAILURE;
+    }
+
+    return SUCCESS;
+}

--- a/src/api/response_builder.h
+++ b/src/api/response_builder.h
@@ -1,0 +1,27 @@
+#ifndef RESPONSE_BUILDER_H
+#define RESPONSE_BUILDER_H
+
+#include "executor_result.h"
+
+/*
+ * DbResult를 JSON body와 HTTP 상태 코드로 변환한다.
+ */
+int build_query_json_response(const DbResult *result, int *out_status_code,
+                              char **out_body);
+
+/*
+ * 단순 에러 JSON body를 생성한다.
+ */
+int build_json_error_response(int status_code, const char *message, char **out_body);
+
+/*
+ * 상태 확인용 JSON body를 생성한다.
+ */
+int build_health_json_response(char **out_body);
+
+/*
+ * JSON body를 완전한 HTTP/1.1 응답 문자열로 감싼다.
+ */
+int build_http_response(int status_code, const char *body, char **out_response);
+
+#endif

--- a/src/concurrency/job_queue.c
+++ b/src/concurrency/job_queue.c
@@ -1,0 +1,100 @@
+#include "job_queue.h"
+
+#include "utils.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+int queue_init(JobQueue *queue, int capacity) {
+    if (queue == NULL || capacity <= 0) {
+        return FAILURE;
+    }
+
+    memset(queue, 0, sizeof(*queue));
+    queue->client_fds = (int *)malloc((size_t)capacity * sizeof(int));
+    if (queue->client_fds == NULL) {
+        return FAILURE;
+    }
+
+    queue->capacity = capacity;
+    if (pthread_mutex_init(&queue->mutex, NULL) != 0) {
+        free(queue->client_fds);
+        queue->client_fds = NULL;
+        return FAILURE;
+    }
+
+    if (pthread_cond_init(&queue->not_empty, NULL) != 0) {
+        pthread_mutex_destroy(&queue->mutex);
+        free(queue->client_fds);
+        queue->client_fds = NULL;
+        return FAILURE;
+    }
+
+    return SUCCESS;
+}
+
+int queue_push(JobQueue *queue, int client_fd) {
+    int status;
+
+    if (queue == NULL) {
+        return FAILURE;
+    }
+
+    status = FAILURE;
+    pthread_mutex_lock(&queue->mutex);
+    if (!queue->shutting_down && queue->count < queue->capacity) {
+        queue->client_fds[queue->tail] = client_fd;
+        queue->tail = (queue->tail + 1) % queue->capacity;
+        queue->count++;
+        status = SUCCESS;
+        pthread_cond_signal(&queue->not_empty);
+    }
+    pthread_mutex_unlock(&queue->mutex);
+    return status;
+}
+
+int queue_pop(JobQueue *queue, int *out_client_fd) {
+    if (queue == NULL || out_client_fd == NULL) {
+        return FAILURE;
+    }
+
+    pthread_mutex_lock(&queue->mutex);
+    while (queue->count == 0 && !queue->shutting_down) {
+        pthread_cond_wait(&queue->not_empty, &queue->mutex);
+    }
+
+    if (queue->count == 0 && queue->shutting_down) {
+        pthread_mutex_unlock(&queue->mutex);
+        return FAILURE;
+    }
+
+    *out_client_fd = queue->client_fds[queue->head];
+    queue->head = (queue->head + 1) % queue->capacity;
+    queue->count--;
+    pthread_mutex_unlock(&queue->mutex);
+    return SUCCESS;
+}
+
+void queue_shutdown(JobQueue *queue) {
+    if (queue == NULL) {
+        return;
+    }
+
+    pthread_mutex_lock(&queue->mutex);
+    queue->shutting_down = 1;
+    pthread_cond_broadcast(&queue->not_empty);
+    pthread_mutex_unlock(&queue->mutex);
+}
+
+void queue_destroy(JobQueue *queue) {
+    if (queue == NULL) {
+        return;
+    }
+
+    pthread_cond_destroy(&queue->not_empty);
+    pthread_mutex_destroy(&queue->mutex);
+    free(queue->client_fds);
+    queue->client_fds = NULL;
+    queue->capacity = 0;
+    queue->count = 0;
+}

--- a/src/concurrency/job_queue.h
+++ b/src/concurrency/job_queue.h
@@ -1,0 +1,43 @@
+#ifndef JOB_QUEUE_H
+#define JOB_QUEUE_H
+
+#include <pthread.h>
+
+typedef struct {
+    int *client_fds;
+    int capacity;
+    int head;
+    int tail;
+    int count;
+    int shutting_down;
+    pthread_mutex_t mutex;
+    pthread_cond_t not_empty;
+} JobQueue;
+
+/*
+ * bounded job queue를 초기화한다.
+ */
+int queue_init(JobQueue *queue, int capacity);
+
+/*
+ * 큐가 가득 차지 않았으면 client fd를 즉시 push한다.
+ */
+int queue_push(JobQueue *queue, int client_fd);
+
+/*
+ * 다음 client fd를 pop한다.
+ * shutdown 이후 큐가 비어 있으면 FAILURE를 반환한다.
+ */
+int queue_pop(JobQueue *queue, int *out_client_fd);
+
+/*
+ * queue shutdown 상태를 켜고 대기 중인 worker를 깨운다.
+ */
+void queue_shutdown(JobQueue *queue);
+
+/*
+ * queue 내부 자원을 정리한다.
+ */
+void queue_destroy(JobQueue *queue);
+
+#endif

--- a/src/concurrency/lock_manager.c
+++ b/src/concurrency/lock_manager.c
@@ -1,0 +1,103 @@
+#include "lock_manager.h"
+
+#include "utils.h"
+
+#include <pthread.h>
+#include <string.h>
+
+typedef struct {
+    int initialized;
+    LockPolicy policy;
+    int tokenizer_cache_lock_enabled;
+    pthread_mutex_t db_mutex;
+    pthread_rwlock_t db_rwlock;
+    pthread_mutex_t tokenizer_cache_mutex;
+} LockManagerState;
+
+static LockManagerState lock_manager_state;
+
+int init_lock_manager(LockPolicy policy) {
+    destroy_lock_manager();
+    memset(&lock_manager_state, 0, sizeof(lock_manager_state));
+
+    if (pthread_mutex_init(&lock_manager_state.db_mutex, NULL) != 0) {
+        return FAILURE;
+    }
+
+    if (pthread_rwlock_init(&lock_manager_state.db_rwlock, NULL) != 0) {
+        pthread_mutex_destroy(&lock_manager_state.db_mutex);
+        return FAILURE;
+    }
+
+    if (pthread_mutex_init(&lock_manager_state.tokenizer_cache_mutex, NULL) != 0) {
+        pthread_rwlock_destroy(&lock_manager_state.db_rwlock);
+        pthread_mutex_destroy(&lock_manager_state.db_mutex);
+        return FAILURE;
+    }
+
+    lock_manager_state.initialized = 1;
+    lock_manager_state.policy = policy;
+    lock_manager_state.tokenizer_cache_lock_enabled =
+        (policy == LOCK_POLICY_SPLIT_RWLOCK);
+    return SUCCESS;
+}
+
+int lock_db_for_query(QueryLockMode mode) {
+    if (!lock_manager_state.initialized) {
+        return FAILURE;
+    }
+
+    if (lock_manager_state.policy == LOCK_POLICY_GLOBAL_MUTEX) {
+        return pthread_mutex_lock(&lock_manager_state.db_mutex) == 0 ? SUCCESS : FAILURE;
+    }
+
+    if (mode == QUERY_LOCK_READ) {
+        return pthread_rwlock_rdlock(&lock_manager_state.db_rwlock) == 0 ?
+               SUCCESS : FAILURE;
+    }
+
+    return pthread_rwlock_wrlock(&lock_manager_state.db_rwlock) == 0 ?
+           SUCCESS : FAILURE;
+}
+
+void unlock_db_for_query(QueryLockMode mode) {
+    (void)mode;
+
+    if (!lock_manager_state.initialized) {
+        return;
+    }
+
+    if (lock_manager_state.policy == LOCK_POLICY_GLOBAL_MUTEX) {
+        pthread_mutex_unlock(&lock_manager_state.db_mutex);
+        return;
+    }
+
+    pthread_rwlock_unlock(&lock_manager_state.db_rwlock);
+}
+
+void lock_tokenizer_cache(void) {
+    if (!lock_manager_state.initialized || !lock_manager_state.tokenizer_cache_lock_enabled) {
+        return;
+    }
+
+    pthread_mutex_lock(&lock_manager_state.tokenizer_cache_mutex);
+}
+
+void unlock_tokenizer_cache(void) {
+    if (!lock_manager_state.initialized || !lock_manager_state.tokenizer_cache_lock_enabled) {
+        return;
+    }
+
+    pthread_mutex_unlock(&lock_manager_state.tokenizer_cache_mutex);
+}
+
+void destroy_lock_manager(void) {
+    if (!lock_manager_state.initialized) {
+        return;
+    }
+
+    pthread_mutex_destroy(&lock_manager_state.tokenizer_cache_mutex);
+    pthread_rwlock_destroy(&lock_manager_state.db_rwlock);
+    pthread_mutex_destroy(&lock_manager_state.db_mutex);
+    memset(&lock_manager_state, 0, sizeof(lock_manager_state));
+}

--- a/src/concurrency/lock_manager.h
+++ b/src/concurrency/lock_manager.h
@@ -1,0 +1,45 @@
+#ifndef LOCK_MANAGER_H
+#define LOCK_MANAGER_H
+
+typedef enum {
+    LOCK_POLICY_GLOBAL_MUTEX,
+    LOCK_POLICY_SPLIT_RWLOCK
+} LockPolicy;
+
+typedef enum {
+    QUERY_LOCK_READ,
+    QUERY_LOCK_WRITE
+} QueryLockMode;
+
+/*
+ * 현재 단계의 락 정책으로 lock manager를 초기화한다.
+ */
+int init_lock_manager(LockPolicy policy);
+
+/*
+ * SQL 실행 전에 현재 정책에 맞는 DB 락을 획득한다.
+ */
+int lock_db_for_query(QueryLockMode mode);
+
+/*
+ * SQL 실행 후 현재 정책에 맞는 DB 락을 해제한다.
+ */
+void unlock_db_for_query(QueryLockMode mode);
+
+/*
+ * tokenizer 전역 캐시 접근 전용 락이다.
+ * Step 5에서는 no-op이고 Step 6에서 활성화된다.
+ */
+void lock_tokenizer_cache(void);
+
+/*
+ * tokenizer 전역 캐시 락을 해제한다.
+ */
+void unlock_tokenizer_cache(void);
+
+/*
+ * lock manager 내부 자원을 정리한다.
+ */
+void destroy_lock_manager(void);
+
+#endif

--- a/src/concurrency/thread_pool.c
+++ b/src/concurrency/thread_pool.c
@@ -1,0 +1,98 @@
+#include "thread_pool.h"
+
+#include "utils.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+    ThreadPool *pool;
+} ThreadPoolWorkerArgs;
+
+static void *thread_pool_worker_main(void *arg) {
+    ThreadPool *pool;
+    int client_fd;
+
+    pool = ((ThreadPoolWorkerArgs *)arg)->pool;
+    free(arg);
+
+    while (queue_pop(&pool->queue, &client_fd) == SUCCESS) {
+        pool->handler(client_fd, pool->handler_context);
+    }
+
+    return NULL;
+}
+
+int thread_pool_init(ThreadPool *pool, int worker_count, int queue_capacity,
+                     ThreadPoolJobHandler handler, void *context) {
+    int i;
+
+    if (pool == NULL || worker_count <= 0 || queue_capacity <= 0 ||
+        handler == NULL) {
+        return FAILURE;
+    }
+
+    memset(pool, 0, sizeof(*pool));
+    if (queue_init(&pool->queue, queue_capacity) != SUCCESS) {
+        return FAILURE;
+    }
+
+    pool->workers = (pthread_t *)calloc((size_t)worker_count, sizeof(pthread_t));
+    if (pool->workers == NULL) {
+        queue_destroy(&pool->queue);
+        return FAILURE;
+    }
+
+    pool->worker_count = worker_count;
+    pool->handler = handler;
+    pool->handler_context = context;
+
+    for (i = 0; i < worker_count; i++) {
+        ThreadPoolWorkerArgs *args;
+
+        args = (ThreadPoolWorkerArgs *)malloc(sizeof(ThreadPoolWorkerArgs));
+        if (args == NULL) {
+            thread_pool_shutdown(pool);
+            return FAILURE;
+        }
+        args->pool = pool;
+
+        if (pthread_create(&pool->workers[i], NULL,
+                           thread_pool_worker_main, args) != 0) {
+            free(args);
+            pool->worker_count = i;
+            thread_pool_shutdown(pool);
+            return FAILURE;
+        }
+    }
+
+    return SUCCESS;
+}
+
+int thread_pool_submit(ThreadPool *pool, int client_fd) {
+    if (pool == NULL) {
+        return FAILURE;
+    }
+
+    return queue_push(&pool->queue, client_fd);
+}
+
+void thread_pool_shutdown(ThreadPool *pool) {
+    int i;
+
+    if (pool == NULL) {
+        return;
+    }
+
+    queue_shutdown(&pool->queue);
+    for (i = 0; i < pool->worker_count; i++) {
+        if (pool->workers[i] != 0) {
+            pthread_join(pool->workers[i], NULL);
+        }
+    }
+
+    free(pool->workers);
+    pool->workers = NULL;
+    pool->worker_count = 0;
+    queue_destroy(&pool->queue);
+}

--- a/src/concurrency/thread_pool.h
+++ b/src/concurrency/thread_pool.h
@@ -1,0 +1,35 @@
+#ifndef THREAD_POOL_H
+#define THREAD_POOL_H
+
+#include "job_queue.h"
+
+#include <pthread.h>
+
+typedef void (*ThreadPoolJobHandler)(int client_fd, void *context);
+
+typedef struct {
+    pthread_t *workers;
+    int worker_count;
+    ThreadPoolJobHandler handler;
+    void *handler_context;
+    JobQueue queue;
+} ThreadPool;
+
+/*
+ * worker thread와 bounded queue를 포함한 thread pool을 초기화한다.
+ */
+int thread_pool_init(ThreadPool *pool, int worker_count, int queue_capacity,
+                     ThreadPoolJobHandler handler, void *context);
+
+/*
+ * client fd를 queue에 제출한다.
+ * queue가 가득 차면 즉시 FAILURE를 반환한다.
+ */
+int thread_pool_submit(ThreadPool *pool, int client_fd);
+
+/*
+ * thread pool을 종료하고 모든 worker를 join한 뒤 내부 자원을 정리한다.
+ */
+void thread_pool_shutdown(ThreadPool *pool);
+
+#endif

--- a/src/db/db_engine_facade.c
+++ b/src/db/db_engine_facade.c
@@ -21,12 +21,42 @@ static int db_engine_fail(DbResult *out_result, const char *message) {
     return FAILURE;
 }
 
-static QueryLockMode db_engine_detect_query_lock_mode(const char *sql) {
-    while (sql != NULL && *sql != '\0' && isspace((unsigned char)*sql)) {
-        sql++;
+static int db_engine_parse_statement(const char *sql, SqlStatement *out_statement) {
+    Token *tokens;
+    int token_count;
+    char *working_sql;
+    int status;
+
+    if (sql == NULL || out_statement == NULL) {
+        return FAILURE;
     }
 
-    if (sql != NULL && strncasecmp(sql, "SELECT", 6) == 0) {
+    working_sql = utils_strdup(sql);
+    if (working_sql == NULL) {
+        return FAILURE;
+    }
+
+    utils_trim(working_sql);
+    if (working_sql[0] == '\0') {
+        free(working_sql);
+        return FAILURE;
+    }
+
+    tokens = tokenizer_tokenize(working_sql, &token_count);
+    if (tokens == NULL || token_count == 0) {
+        free(tokens);
+        free(working_sql);
+        return FAILURE;
+    }
+
+    status = parser_parse(tokens, token_count, out_statement);
+    free(tokens);
+    free(working_sql);
+    return status;
+}
+
+static QueryLockMode db_engine_choose_initial_lock_mode(const SqlStatement *statement) {
+    if (statement != NULL && statement->type == SQL_SELECT) {
         return QUERY_LOCK_READ;
     }
 
@@ -38,7 +68,7 @@ int db_engine_init(DbEngine *engine) {
         return FAILURE;
     }
 
-    if (init_lock_manager(LOCK_POLICY_GLOBAL_MUTEX) != SUCCESS) {
+    if (init_lock_manager(LOCK_POLICY_SPLIT_RWLOCK) != SUCCESS) {
         return FAILURE;
     }
 
@@ -47,16 +77,32 @@ int db_engine_init(DbEngine *engine) {
 }
 
 int execute_query_with_lock(DbEngine *engine, const char *sql, DbResult *out_result) {
+    SqlStatement statement;
     QueryLockMode lock_mode;
+    int parsed_for_locking;
     int status;
 
     if (engine == NULL || sql == NULL || out_result == NULL) {
         return FAILURE;
     }
 
-    lock_mode = db_engine_detect_query_lock_mode(sql);
+    parsed_for_locking = db_engine_parse_statement(sql, &statement) == SUCCESS;
+    lock_mode = db_engine_choose_initial_lock_mode(parsed_for_locking ? &statement : NULL);
     if (lock_db_for_query(lock_mode) != SUCCESS) {
         return db_engine_fail(out_result, "Failed to acquire DB lock.");
+    }
+
+    /*
+     * 단일 활성 테이블 구조에서는 아직 적재되지 않은 SELECT가
+     * 런타임 상태를 바꾸므로 write lock으로 승격해 직렬화한다.
+     */
+    if (parsed_for_locking && lock_mode == QUERY_LOCK_READ &&
+        !table_runtime_is_loaded_for(statement.select.table_name)) {
+        unlock_db_for_query(lock_mode);
+        lock_mode = QUERY_LOCK_WRITE;
+        if (lock_db_for_query(lock_mode) != SUCCESS) {
+            return db_engine_fail(out_result, "Failed to upgrade DB lock.");
+        }
     }
 
     status = db_execute_sql(engine, sql, out_result);

--- a/src/db/db_engine_facade.c
+++ b/src/db/db_engine_facade.c
@@ -1,12 +1,15 @@
 #include "db_engine_facade.h"
 
+#include "lock_manager.h"
 #include "executor.h"
 #include "parser.h"
 #include "table_runtime.h"
 #include "tokenizer.h"
 #include "utils.h"
 
+#include <ctype.h>
 #include <stdlib.h>
+#include <strings.h>
 
 /*
  * facade 공통 실패 경로에서 DbResult에 에러 메시지를 채운다.
@@ -18,8 +21,24 @@ static int db_engine_fail(DbResult *out_result, const char *message) {
     return FAILURE;
 }
 
+static QueryLockMode db_engine_detect_query_lock_mode(const char *sql) {
+    while (sql != NULL && *sql != '\0' && isspace((unsigned char)*sql)) {
+        sql++;
+    }
+
+    if (sql != NULL && strncasecmp(sql, "SELECT", 6) == 0) {
+        return QUERY_LOCK_READ;
+    }
+
+    return QUERY_LOCK_WRITE;
+}
+
 int db_engine_init(DbEngine *engine) {
     if (engine == NULL) {
+        return FAILURE;
+    }
+
+    if (init_lock_manager(LOCK_POLICY_GLOBAL_MUTEX) != SUCCESS) {
         return FAILURE;
     }
 
@@ -28,7 +47,21 @@ int db_engine_init(DbEngine *engine) {
 }
 
 int execute_query_with_lock(DbEngine *engine, const char *sql, DbResult *out_result) {
-    return db_execute_sql(engine, sql, out_result);
+    QueryLockMode lock_mode;
+    int status;
+
+    if (engine == NULL || sql == NULL || out_result == NULL) {
+        return FAILURE;
+    }
+
+    lock_mode = db_engine_detect_query_lock_mode(sql);
+    if (lock_db_for_query(lock_mode) != SUCCESS) {
+        return db_engine_fail(out_result, "Failed to acquire DB lock.");
+    }
+
+    status = db_execute_sql(engine, sql, out_result);
+    unlock_db_for_query(lock_mode);
+    return status;
 }
 
 int db_execute_sql(DbEngine *engine, const char *sql, DbResult *out_result) {
@@ -89,6 +122,7 @@ int db_execute_sql(DbEngine *engine, const char *sql, DbResult *out_result) {
 void db_engine_shutdown(DbEngine *engine) {
     table_runtime_cleanup();
     tokenizer_cleanup_cache();
+    destroy_lock_manager();
 
     if (engine == NULL) {
         return;

--- a/src/db/table_runtime.c
+++ b/src/db/table_runtime.c
@@ -452,6 +452,19 @@ int table_load_from_storage_if_needed(TableRuntime *table, const char *table_nam
     return SUCCESS;
 }
 
+int table_runtime_is_loaded_for(const char *table_name) {
+    if (table_name == NULL || !table_runtime_has_active) {
+        return 0;
+    }
+
+    if (!table_runtime_active.loaded) {
+        return 0;
+    }
+
+    return table_runtime_active.table_name[0] != '\0' &&
+           utils_equals_ignore_case(table_runtime_active.table_name, table_name);
+}
+
 int table_insert_row(TableRuntime *table, const InsertStatement *stmt,
                      int *out_row_index) {
     char **row;

--- a/src/db/table_runtime.h
+++ b/src/db/table_runtime.h
@@ -46,6 +46,12 @@ TableRuntime *table_get_or_load(const char *table_name);
 int table_load_from_storage_if_needed(TableRuntime *table, const char *table_name);
 
 /*
+ * 현재 활성 런타임이 주어진 테이블을 이미 메모리에 적재했는지 확인한다.
+ * 이 함수는 DB 락을 잡은 상태에서 호출하는 것을 전제로 한다.
+ */
+int table_runtime_is_loaded_for(const char *table_name);
+
+/*
  * INSERT 문 기준으로 auto id를 붙여 메모리 행을 추가한다.
  * 성공 시 새 row_index를 out_row_index에 저장한다.
  */

--- a/src/db/tokenizer.c
+++ b/src/db/tokenizer.c
@@ -1,5 +1,7 @@
 #include "tokenizer.h"
 
+#include "lock_manager.h"
+
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -93,6 +95,7 @@ static Token *tokenizer_lookup_cache(const char *sql, int *token_count) {
         return NULL;
     }
 
+    lock_tokenizer_cache();
     previous = NULL;
     entry = tokenizer_cache_head;
     while (entry != NULL) {
@@ -105,11 +108,13 @@ static Token *tokenizer_lookup_cache(const char *sql, int *token_count) {
 
             copy = tokenizer_clone_tokens(entry->tokens, entry->token_count);
             if (copy == NULL) {
+                unlock_tokenizer_cache();
                 return NULL;
             }
 
             *token_count = entry->token_count;
             tokenizer_cache_hit_count++;
+            unlock_tokenizer_cache();
             return copy;
         }
 
@@ -117,6 +122,7 @@ static Token *tokenizer_lookup_cache(const char *sql, int *token_count) {
         entry = entry->next;
     }
 
+    unlock_tokenizer_cache();
     return NULL;
 }
 
@@ -151,6 +157,7 @@ static int tokenizer_store_cache(const char *sql, const Token *tokens,
         return FAILURE;
     }
 
+    lock_tokenizer_cache();
     entry->token_count = token_count;
     entry->next = tokenizer_cache_head;
     tokenizer_cache_head = entry;
@@ -160,6 +167,7 @@ static int tokenizer_store_cache(const char *sql, const Token *tokens,
         tokenizer_evict_oldest_cache_entry();
     }
 
+    unlock_tokenizer_cache();
     return SUCCESS;
 }
 
@@ -529,6 +537,7 @@ void tokenizer_cleanup_cache(void) {
     SoftParserCacheEntry *entry;
     SoftParserCacheEntry *next;
 
+    lock_tokenizer_cache();
     entry = tokenizer_cache_head;
     while (entry != NULL) {
         next = entry->next;
@@ -539,20 +548,31 @@ void tokenizer_cleanup_cache(void) {
     tokenizer_cache_head = NULL;
     tokenizer_cache_entry_count = 0;
     tokenizer_cache_hit_count = 0;
+    unlock_tokenizer_cache();
 }
 
 /*
  * 현재 파서 캐시에 저장된 SQL 문 개수를 반환한다.
  */
 int tokenizer_get_cache_entry_count(void) {
-    return tokenizer_cache_entry_count;
+    int count;
+
+    lock_tokenizer_cache();
+    count = tokenizer_cache_entry_count;
+    unlock_tokenizer_cache();
+    return count;
 }
 
 /*
  * 마지막 캐시 정리 이후 발생한 파서 캐시 히트 수를 반환한다.
  */
 int tokenizer_get_cache_hit_count(void) {
-    return tokenizer_cache_hit_count;
+    int hit_count;
+
+    lock_tokenizer_cache();
+    hit_count = tokenizer_cache_hit_count;
+    unlock_tokenizer_cache();
+    return hit_count;
 }
 
 /*

--- a/tests/api/test_api_concurrency_smoke.sh
+++ b/tests/api/test_api_concurrency_smoke.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+ROOT_DIR=$(cd "$SCRIPT_DIR/../.." && pwd)
+PORT=$((25000 + RANDOM % 15000))
+SERVER_PID=""
+INSERT_PIDS=()
+TMP_DIR=$(mktemp -d)
+
+cleanup() {
+    if [ -n "$SERVER_PID" ]; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+    fi
+    rm -rf "$TMP_DIR"
+}
+
+trap cleanup EXIT
+
+cd "$ROOT_DIR"
+rm -f data/api_concurrent_users.csv
+
+./api_server "$PORT" 4 16 >/tmp/week8_api_concurrency_server.log 2>&1 &
+SERVER_PID=$!
+
+for _ in $(seq 1 40); do
+    if curl -s "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.25
+done
+
+for i in $(seq 1 10); do
+    curl -s -i -X POST "http://127.0.0.1:${PORT}/query" \
+        -H "Content-Type: application/json" \
+        --data "{\"sql\":\"INSERT INTO api_concurrent_users (name, age) VALUES ('user${i}', ${i});\"}" \
+        >"${TMP_DIR}/insert_${i}.txt" &
+    INSERT_PIDS+=($!)
+done
+
+for pid in "${INSERT_PIDS[@]}"; do
+    wait "$pid"
+done
+
+for i in $(seq 1 10); do
+    if ! grep -q 'HTTP/1.1 200 OK' "${TMP_DIR}/insert_${i}.txt"; then
+        echo "[FAIL] api concurrent insert ${i}"
+        cat "${TMP_DIR}/insert_${i}.txt"
+        exit 1
+    fi
+done
+
+select_response=$(curl -s -i -X POST "http://127.0.0.1:${PORT}/query" \
+    -H "Content-Type: application/json" \
+    --data '{"sql":"SELECT id, name FROM api_concurrent_users;"}')
+
+if ! echo "$select_response" | grep -q 'HTTP/1.1 200 OK'; then
+    echo "[FAIL] api concurrency select status"
+    echo "$select_response"
+    exit 1
+fi
+
+if ! echo "$select_response" | grep -q '"row_count":10'; then
+    echo "[FAIL] api concurrency row count"
+    echo "$select_response"
+    exit 1
+fi
+
+echo "[PASS] api_concurrency_smoke"

--- a/tests/api/test_api_parallel_select_smoke.sh
+++ b/tests/api/test_api_parallel_select_smoke.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+ROOT_DIR=$(cd "$SCRIPT_DIR/../.." && pwd)
+PORT=$((26000 + RANDOM % 12000))
+SERVER_PID=""
+TMP_DIR=$(mktemp -d)
+SELECT_PIDS=()
+
+cleanup() {
+    if [ -n "$SERVER_PID" ]; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+    fi
+    rm -rf "$TMP_DIR"
+}
+
+trap cleanup EXIT
+
+cd "$ROOT_DIR"
+rm -f data/api_parallel_users.csv
+
+./api_server "$PORT" 4 16 >/tmp/week8_api_parallel_server.log 2>&1 &
+SERVER_PID=$!
+
+for _ in $(seq 1 40); do
+    if curl -s "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.25
+done
+
+for i in $(seq 1 3); do
+    curl -s -i -X POST "http://127.0.0.1:${PORT}/query" \
+        -H "Content-Type: application/json" \
+        --data "{\"sql\":\"INSERT INTO api_parallel_users (name, age) VALUES ('reader${i}', ${i});\"}" \
+        >/tmp/week8_api_parallel_insert.txt
+done
+
+for i in $(seq 1 8); do
+    curl -s -i -X POST "http://127.0.0.1:${PORT}/query" \
+        -H "Content-Type: application/json" \
+        --data '{"sql":"SELECT id, name FROM api_parallel_users;"}' \
+        >"${TMP_DIR}/select_${i}.txt" &
+    SELECT_PIDS+=($!)
+done
+
+for pid in "${SELECT_PIDS[@]}"; do
+    wait "$pid"
+done
+
+for i in $(seq 1 8); do
+    if ! grep -q 'HTTP/1.1 200 OK' "${TMP_DIR}/select_${i}.txt"; then
+        echo "[FAIL] api parallel select status ${i}"
+        cat "${TMP_DIR}/select_${i}.txt"
+        exit 1
+    fi
+    if ! grep -q '"row_count":3' "${TMP_DIR}/select_${i}.txt"; then
+        echo "[FAIL] api parallel select row count ${i}"
+        cat "${TMP_DIR}/select_${i}.txt"
+        exit 1
+    fi
+done
+
+echo "[PASS] api_parallel_select_smoke"

--- a/tests/api/test_api_smoke.sh
+++ b/tests/api/test_api_smoke.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+ROOT_DIR=$(cd "$SCRIPT_DIR/../.." && pwd)
+PORT=$((20000 + RANDOM % 20000))
+SERVER_PID=""
+
+cleanup() {
+    if [ -n "$SERVER_PID" ]; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+    fi
+}
+
+trap cleanup EXIT
+
+cd "$ROOT_DIR"
+rm -f data/api_users.csv
+
+./api_server "$PORT" >/tmp/week8_api_server.log 2>&1 &
+SERVER_PID=$!
+
+for _ in $(seq 1 40); do
+    if curl -s "http://127.0.0.1:${PORT}/health" >/tmp/week8_api_health.txt 2>/dev/null; then
+        break
+    fi
+    sleep 0.25
+done
+
+health_response=$(curl -s -i "http://127.0.0.1:${PORT}/health")
+if ! echo "$health_response" | grep -q 'HTTP/1.1 200 OK'; then
+    echo "[FAIL] api health status"
+    echo "$health_response"
+    exit 1
+fi
+
+if ! echo "$health_response" | grep -q '{"status":"ok"}'; then
+    echo "[FAIL] api health body"
+    echo "$health_response"
+    exit 1
+fi
+
+insert_response=$(curl -s -i -X POST "http://127.0.0.1:${PORT}/query" \
+    -H "Content-Type: application/json" \
+    --data '{"sql":"INSERT INTO api_users (name, age) VALUES ('\''Alice'\'', 30);"}')
+
+if ! echo "$insert_response" | grep -q 'HTTP/1.1 200 OK'; then
+    echo "[FAIL] api insert status"
+    echo "$insert_response"
+    exit 1
+fi
+
+if ! echo "$insert_response" | grep -q '"rows_affected":1'; then
+    echo "[FAIL] api insert body"
+    echo "$insert_response"
+    exit 1
+fi
+
+select_response=$(curl -s -i -X POST "http://127.0.0.1:${PORT}/query" \
+    -H "Content-Type: application/json" \
+    --data '{"sql":"SELECT name FROM api_users WHERE id = 1;"}')
+
+if ! echo "$select_response" | grep -q 'HTTP/1.1 200 OK'; then
+    echo "[FAIL] api select status"
+    echo "$select_response"
+    exit 1
+fi
+
+if ! echo "$select_response" | grep -q '"Alice"'; then
+    echo "[FAIL] api select body"
+    echo "$select_response"
+    exit 1
+fi
+
+if ! echo "$select_response" | grep -q '"used_id_index":true'; then
+    echo "[FAIL] api select index usage"
+    echo "$select_response"
+    exit 1
+fi
+
+echo "[PASS] api_smoke"

--- a/tests/concurrency/test_thread_pool.c
+++ b/tests/concurrency/test_thread_pool.c
@@ -1,0 +1,119 @@
+#include "thread_pool.h"
+#include "utils.h"
+
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+typedef struct {
+    pthread_mutex_t mutex;
+    int handled_count;
+    int handled_sum;
+} HandlerState;
+
+static int assert_true(int condition, const char *message) {
+    if (!condition) {
+        fprintf(stderr, "[FAIL] %s\n", message);
+        return FAILURE;
+    }
+    return SUCCESS;
+}
+
+static void test_handler(int client_fd, void *context) {
+    HandlerState *state;
+
+    state = (HandlerState *)context;
+    usleep(100000);
+
+    pthread_mutex_lock(&state->mutex);
+    state->handled_count++;
+    state->handled_sum += client_fd;
+    pthread_mutex_unlock(&state->mutex);
+}
+
+static int wait_for_count(HandlerState *state, int expected_count) {
+    int retries;
+
+    for (retries = 0; retries < 100; retries++) {
+        int count;
+
+        pthread_mutex_lock(&state->mutex);
+        count = state->handled_count;
+        pthread_mutex_unlock(&state->mutex);
+
+        if (count >= expected_count) {
+            return SUCCESS;
+        }
+        usleep(20000);
+    }
+
+    return FAILURE;
+}
+
+int main(void) {
+    HandlerState state;
+    ThreadPool pool;
+
+    pthread_mutex_init(&state.mutex, NULL);
+    state.handled_count = 0;
+    state.handled_sum = 0;
+
+    if (assert_true(thread_pool_init(&pool, 2, 8, test_handler, &state) == SUCCESS,
+                    "thread_pool_init should create workers") != SUCCESS) {
+        pthread_mutex_destroy(&state.mutex);
+        return EXIT_FAILURE;
+    }
+
+    if (assert_true(thread_pool_submit(&pool, 1) == SUCCESS, "submit 1 should succeed") != SUCCESS ||
+        assert_true(thread_pool_submit(&pool, 2) == SUCCESS, "submit 2 should succeed") != SUCCESS ||
+        assert_true(thread_pool_submit(&pool, 3) == SUCCESS, "submit 3 should succeed") != SUCCESS ||
+        assert_true(thread_pool_submit(&pool, 4) == SUCCESS, "submit 4 should succeed") != SUCCESS ||
+        assert_true(thread_pool_submit(&pool, 5) == SUCCESS, "submit 5 should succeed") != SUCCESS ||
+        assert_true(wait_for_count(&state, 5) == SUCCESS,
+                    "workers should process submitted jobs") != SUCCESS) {
+        thread_pool_shutdown(&pool);
+        pthread_mutex_destroy(&state.mutex);
+        return EXIT_FAILURE;
+    }
+
+    if (assert_true(state.handled_sum == 15,
+                    "all submitted jobs should reach the handler") != SUCCESS) {
+        thread_pool_shutdown(&pool);
+        pthread_mutex_destroy(&state.mutex);
+        return EXIT_FAILURE;
+    }
+
+    thread_pool_shutdown(&pool);
+
+    state.handled_count = 0;
+    state.handled_sum = 0;
+    if (assert_true(thread_pool_init(&pool, 1, 1, test_handler, &state) == SUCCESS,
+                    "small thread pool should initialize") != SUCCESS) {
+        pthread_mutex_destroy(&state.mutex);
+        return EXIT_FAILURE;
+    }
+
+    if (assert_true(thread_pool_submit(&pool, 10) == SUCCESS,
+                    "first job should enter the pool") != SUCCESS) {
+        thread_pool_shutdown(&pool);
+        pthread_mutex_destroy(&state.mutex);
+        return EXIT_FAILURE;
+    }
+
+    usleep(50000);
+    if (assert_true(thread_pool_submit(&pool, 20) == SUCCESS,
+                    "second job should occupy the bounded queue") != SUCCESS ||
+        assert_true(thread_pool_submit(&pool, 30) == FAILURE,
+                    "third job should fail immediately when queue is full") != SUCCESS) {
+        thread_pool_shutdown(&pool);
+        pthread_mutex_destroy(&state.mutex);
+        return EXIT_FAILURE;
+    }
+
+    thread_pool_shutdown(&pool);
+    pthread_mutex_destroy(&state.mutex);
+
+    puts("[PASS] thread_pool");
+    return EXIT_SUCCESS;
+}

--- a/tests/concurrency/test_tokenizer_cache_threads.c
+++ b/tests/concurrency/test_tokenizer_cache_threads.c
@@ -1,0 +1,92 @@
+#include "tokenizer.h"
+#include "lock_manager.h"
+#include "utils.h"
+
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+typedef struct {
+    const char *sql;
+    int iterations;
+    int failed;
+} TokenizerWorkerState;
+
+static int assert_true(int condition, const char *message) {
+    if (!condition) {
+        fprintf(stderr, "[FAIL] %s\n", message);
+        return FAILURE;
+    }
+    return SUCCESS;
+}
+
+static void *tokenizer_worker_main(void *arg) {
+    TokenizerWorkerState *state;
+    int i;
+
+    state = (TokenizerWorkerState *)arg;
+    for (i = 0; i < state->iterations; i++) {
+        Token *tokens;
+        int token_count;
+
+        tokens = tokenizer_tokenize(state->sql, &token_count);
+        if (tokens == NULL || token_count == 0) {
+            state->failed = 1;
+            free(tokens);
+            return NULL;
+        }
+        free(tokens);
+    }
+
+    return NULL;
+}
+
+int main(void) {
+    pthread_t threads[8];
+    TokenizerWorkerState workers[8];
+    int i;
+
+    tokenizer_cleanup_cache();
+    if (init_lock_manager(LOCK_POLICY_SPLIT_RWLOCK) != SUCCESS) {
+        return EXIT_FAILURE;
+    }
+
+    for (i = 0; i < 8; i++) {
+        workers[i].sql = (i % 2 == 0)
+                             ? "SELECT name FROM threaded_cache_users WHERE id = 1;"
+                             : "INSERT INTO threaded_cache_users (name, age) VALUES ('Alice', 30);";
+        workers[i].iterations = 200;
+        workers[i].failed = 0;
+        if (pthread_create(&threads[i], NULL, tokenizer_worker_main, &workers[i]) != 0) {
+            return EXIT_FAILURE;
+        }
+    }
+
+    for (i = 0; i < 8; i++) {
+        pthread_join(threads[i], NULL);
+        if (assert_true(workers[i].failed == 0,
+                        "tokenizer threads should tokenize without failure") != SUCCESS) {
+            tokenizer_cleanup_cache();
+            return EXIT_FAILURE;
+        }
+    }
+
+    if (assert_true(tokenizer_get_cache_entry_count() > 0,
+                    "cache entry count should stay readable after threaded access") != SUCCESS ||
+        assert_true(tokenizer_get_cache_hit_count() > 0,
+                    "threaded access should record cache hits") != SUCCESS) {
+        tokenizer_cleanup_cache();
+        return EXIT_FAILURE;
+    }
+
+    tokenizer_cleanup_cache();
+    if (assert_true(tokenizer_get_cache_entry_count() == 0,
+                    "cleanup should still reset tokenizer cache after threaded access") != SUCCESS) {
+        destroy_lock_manager();
+        return EXIT_FAILURE;
+    }
+
+    destroy_lock_manager();
+    puts("[PASS] tokenizer_cache_threads");
+    return EXIT_SUCCESS;
+}

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -69,6 +69,15 @@ else
     FAIL=$((FAIL + 1))
 fi
 
+if bash tests/api/test_api_concurrency_smoke.sh >/tmp/week8_api_concurrency_test.log 2>&1; then
+    echo "[PASS] api_concurrency_smoke"
+    PASS=$((PASS + 1))
+else
+    echo "[FAIL] api_concurrency_smoke"
+    cat /tmp/week8_api_concurrency_test.log
+    FAIL=$((FAIL + 1))
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -47,7 +47,7 @@ for binary in build/tests/db/test_tokenizer build/tests/db/test_parser \
               build/tests/db/test_storage build/tests/db/test_benchmark build/tests/db/test_table_runtime \
               build/tests/db/test_bptree build/tests/db/test_executor build/tests/db/test_db_engine_facade \
               build/tests/db/test_table_storage_loading \
-              build/tests/concurrency/test_thread_pool
+              build/tests/concurrency/test_thread_pool build/tests/concurrency/test_tokenizer_cache_threads
 do
     run_unit_test "$binary"
 done
@@ -75,6 +75,15 @@ if bash tests/api/test_api_concurrency_smoke.sh >/tmp/week8_api_concurrency_test
 else
     echo "[FAIL] api_concurrency_smoke"
     cat /tmp/week8_api_concurrency_test.log
+    FAIL=$((FAIL + 1))
+fi
+
+if bash tests/api/test_api_parallel_select_smoke.sh >/tmp/week8_api_parallel_test.log 2>&1; then
+    echo "[PASS] api_parallel_select_smoke"
+    PASS=$((PASS + 1))
+else
+    echo "[FAIL] api_parallel_select_smoke"
+    cat /tmp/week8_api_parallel_test.log
     FAIL=$((FAIL + 1))
 fi
 

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -59,6 +59,15 @@ run_sql_test "Edge cases" "tests/integration/test_cases/edge_cases.sql" "Lee, Jr
 run_sql_test "Explicit id rejected" "tests/integration/test_cases/duplicate_primary_key.sql" "Explicit id values are not allowed"
 run_sql_test "Delete unsupported" "tests/integration/test_cases/delete_where.sql" "DELETE is not supported in memory runtime mode"
 
+if bash tests/api/test_api_smoke.sh >/tmp/week8_api_test.log 2>&1; then
+    echo "[PASS] api_smoke"
+    PASS=$((PASS + 1))
+else
+    echo "[FAIL] api_smoke"
+    cat /tmp/week8_api_test.log
+    FAIL=$((FAIL + 1))
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -46,7 +46,8 @@ run_sql_test() {
 for binary in build/tests/db/test_tokenizer build/tests/db/test_parser \
               build/tests/db/test_storage build/tests/db/test_benchmark build/tests/db/test_table_runtime \
               build/tests/db/test_bptree build/tests/db/test_executor build/tests/db/test_db_engine_facade \
-              build/tests/db/test_table_storage_loading
+              build/tests/db/test_table_storage_loading \
+              build/tests/concurrency/test_thread_pool
 do
     run_unit_test "$binary"
 done


### PR DESCRIPTION
## 요약
`plan.md` Step 3 기준으로 단일 스레드 API 서버를 구현하고 `GET /health`, `POST /query`를 DB 엔진 facade와 연결했다.

## 변경 사항
- `api_server`, `http_parser`, `request_router`, `response_builder` 모듈을 추가했다.
- `api_server`가 포트를 받아 단일 스레드 accept loop로 HTTP 요청을 처리하도록 구현했다.
- `/health`와 `/query` 라우팅, JSON body의 `sql` 추출, `DbResult` 기반 JSON 응답 생성을 구현했다.
- `api_main`을 실제 서버 진입점으로 교체했다.
- `tests/api/test_api_smoke.sh`를 추가하고 테스트 러너에 연결했다.

## 테스트
- `make tests`
- 로컬 Codex 샌드박스에서는 TCP bind 권한 제한으로 `api_smoke`가 막혀, 동일한 `make tests`를 샌드박스 밖에서 한 번 더 실행해 `api_smoke` 통과를 확인했다.

## 비고
- worker thread, queue, queue full 503 정책은 Step 4에서 이어서 추가한다.

Closes #7
