### PR TITLE
feat: Step 6 tokenizer cache mutex와 DB rwlock 기반 병렬 SELECT 개선

### DIFF
--- a/src/db/db_engine_facade.c
+++ b/src/db/db_engine_facade.c
@@ -21,12 +21,42 @@ static int db_engine_fail(DbResult *out_result, const char *message) {
     return FAILURE;
 }
 
-static QueryLockMode db_engine_detect_query_lock_mode(const char *sql) {
-    while (sql != NULL && *sql != '\0' && isspace((unsigned char)*sql)) {
-        sql++;
+static int db_engine_parse_statement(const char *sql, SqlStatement *out_statement) {
+    Token *tokens;
+    int token_count;
+    char *working_sql;
+    int status;
+
+    if (sql == NULL || out_statement == NULL) {
+        return FAILURE;
     }
 
-    if (sql != NULL && strncasecmp(sql, "SELECT", 6) == 0) {
+    working_sql = utils_strdup(sql);
+    if (working_sql == NULL) {
+        return FAILURE;
+    }
+
+    utils_trim(working_sql);
+    if (working_sql[0] == '\0') {
+        free(working_sql);
+        return FAILURE;
+    }
+
+    tokens = tokenizer_tokenize(working_sql, &token_count);
+    if (tokens == NULL || token_count == 0) {
+        free(tokens);
+        free(working_sql);
+        return FAILURE;
+    }
+
+    status = parser_parse(tokens, token_count, out_statement);
+    free(tokens);
+    free(working_sql);
+    return status;
+}
+
+static QueryLockMode db_engine_choose_initial_lock_mode(const SqlStatement *statement) {
+    if (statement != NULL && statement->type == SQL_SELECT) {
         return QUERY_LOCK_READ;
     }
 
@@ -38,7 +68,7 @@ int db_engine_init(DbEngine *engine) {
         return FAILURE;
     }
 
-    if (init_lock_manager(LOCK_POLICY_GLOBAL_MUTEX) != SUCCESS) {
+    if (init_lock_manager(LOCK_POLICY_SPLIT_RWLOCK) != SUCCESS) {
         return FAILURE;
     }
 
@@ -47,16 +77,32 @@ int db_engine_init(DbEngine *engine) {
 }
 
 int execute_query_with_lock(DbEngine *engine, const char *sql, DbResult *out_result) {
+    SqlStatement statement;
     QueryLockMode lock_mode;
+    int parsed_for_locking;
     int status;
 
     if (engine == NULL || sql == NULL || out_result == NULL) {
         return FAILURE;
     }
 
-    lock_mode = db_engine_detect_query_lock_mode(sql);
+    parsed_for_locking = db_engine_parse_statement(sql, &statement) == SUCCESS;
+    lock_mode = db_engine_choose_initial_lock_mode(parsed_for_locking ? &statement : NULL);
     if (lock_db_for_query(lock_mode) != SUCCESS) {
         return db_engine_fail(out_result, "Failed to acquire DB lock.");
+    }
+
+    /*
+     * 단일 활성 테이블 구조에서는 아직 적재되지 않은 SELECT가
+     * 런타임 상태를 바꾸므로 write lock으로 승격해 직렬화한다.
+     */
+    if (parsed_for_locking && lock_mode == QUERY_LOCK_READ &&
+        !table_runtime_is_loaded_for(statement.select.table_name)) {
+        unlock_db_for_query(lock_mode);
+        lock_mode = QUERY_LOCK_WRITE;
+        if (lock_db_for_query(lock_mode) != SUCCESS) {
+            return db_engine_fail(out_result, "Failed to upgrade DB lock.");
+        }
     }
 
     status = db_execute_sql(engine, sql, out_result);

--- a/src/db/table_runtime.c
+++ b/src/db/table_runtime.c
@@ -452,6 +452,19 @@ int table_load_from_storage_if_needed(TableRuntime *table, const char *table_nam
     return SUCCESS;
 }
 
+int table_runtime_is_loaded_for(const char *table_name) {
+    if (table_name == NULL || !table_runtime_has_active) {
+        return 0;
+    }
+
+    if (!table_runtime_active.loaded) {
+        return 0;
+    }
+
+    return table_runtime_active.table_name[0] != '\0' &&
+           utils_equals_ignore_case(table_runtime_active.table_name, table_name);
+}
+
 int table_insert_row(TableRuntime *table, const InsertStatement *stmt,
                      int *out_row_index) {
     char **row;

--- a/src/db/table_runtime.h
+++ b/src/db/table_runtime.h
@@ -46,6 +46,12 @@ TableRuntime *table_get_or_load(const char *table_name);
 int table_load_from_storage_if_needed(TableRuntime *table, const char *table_name);
 
 /*
+ * 현재 활성 런타임이 주어진 테이블을 이미 메모리에 적재했는지 확인한다.
+ * 이 함수는 DB 락을 잡은 상태에서 호출하는 것을 전제로 한다.
+ */
+int table_runtime_is_loaded_for(const char *table_name);
+
+/*
  * INSERT 문 기준으로 auto id를 붙여 메모리 행을 추가한다.
  * 성공 시 새 row_index를 out_row_index에 저장한다.
  */

--- a/src/db/tokenizer.c
+++ b/src/db/tokenizer.c
@@ -1,5 +1,7 @@
 #include "tokenizer.h"
 
+#include "lock_manager.h"
+
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -93,6 +95,7 @@ static Token *tokenizer_lookup_cache(const char *sql, int *token_count) {
         return NULL;
     }
 
+    lock_tokenizer_cache();
     previous = NULL;
     entry = tokenizer_cache_head;
     while (entry != NULL) {
@@ -105,11 +108,13 @@ static Token *tokenizer_lookup_cache(const char *sql, int *token_count) {
 
             copy = tokenizer_clone_tokens(entry->tokens, entry->token_count);
             if (copy == NULL) {
+                unlock_tokenizer_cache();
                 return NULL;
             }
 
             *token_count = entry->token_count;
             tokenizer_cache_hit_count++;
+            unlock_tokenizer_cache();
             return copy;
         }
 
@@ -117,6 +122,7 @@ static Token *tokenizer_lookup_cache(const char *sql, int *token_count) {
         entry = entry->next;
     }
 
+    unlock_tokenizer_cache();
     return NULL;
 }
 
@@ -151,6 +157,7 @@ static int tokenizer_store_cache(const char *sql, const Token *tokens,
         return FAILURE;
     }
 
+    lock_tokenizer_cache();
     entry->token_count = token_count;
     entry->next = tokenizer_cache_head;
     tokenizer_cache_head = entry;
@@ -160,6 +167,7 @@ static int tokenizer_store_cache(const char *sql, const Token *tokens,
         tokenizer_evict_oldest_cache_entry();
     }
 
+    unlock_tokenizer_cache();
     return SUCCESS;
 }
 
@@ -529,6 +537,7 @@ void tokenizer_cleanup_cache(void) {
     SoftParserCacheEntry *entry;
     SoftParserCacheEntry *next;
 
+    lock_tokenizer_cache();
     entry = tokenizer_cache_head;
     while (entry != NULL) {
         next = entry->next;
@@ -539,20 +548,31 @@ void tokenizer_cleanup_cache(void) {
     tokenizer_cache_head = NULL;
     tokenizer_cache_entry_count = 0;
     tokenizer_cache_hit_count = 0;
+    unlock_tokenizer_cache();
 }
 
 /*
  * 현재 파서 캐시에 저장된 SQL 문 개수를 반환한다.
  */
 int tokenizer_get_cache_entry_count(void) {
-    return tokenizer_cache_entry_count;
+    int count;
+
+    lock_tokenizer_cache();
+    count = tokenizer_cache_entry_count;
+    unlock_tokenizer_cache();
+    return count;
 }
 
 /*
  * 마지막 캐시 정리 이후 발생한 파서 캐시 히트 수를 반환한다.
  */
 int tokenizer_get_cache_hit_count(void) {
-    return tokenizer_cache_hit_count;
+    int hit_count;
+
+    lock_tokenizer_cache();
+    hit_count = tokenizer_cache_hit_count;
+    unlock_tokenizer_cache();
+    return hit_count;
 }
 
 /*

--- a/tests/api/test_api_parallel_select_smoke.sh
+++ b/tests/api/test_api_parallel_select_smoke.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+ROOT_DIR=$(cd "$SCRIPT_DIR/../.." && pwd)
+PORT=$((26000 + RANDOM % 12000))
+SERVER_PID=""
+TMP_DIR=$(mktemp -d)
+SELECT_PIDS=()
+
+cleanup() {
+    if [ -n "$SERVER_PID" ]; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+    fi
+    rm -rf "$TMP_DIR"
+}
+
+trap cleanup EXIT
+
+cd "$ROOT_DIR"
+rm -f data/api_parallel_users.csv
+
+./api_server "$PORT" 4 16 >/tmp/week8_api_parallel_server.log 2>&1 &
+SERVER_PID=$!
+
+for _ in $(seq 1 40); do
+    if curl -s "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.25
+done
+
+for i in $(seq 1 3); do
+    curl -s -i -X POST "http://127.0.0.1:${PORT}/query" \
+        -H "Content-Type: application/json" \
+        --data "{\"sql\":\"INSERT INTO api_parallel_users (name, age) VALUES ('reader${i}', ${i});\"}" \
+        >/tmp/week8_api_parallel_insert.txt
+done
+
+for i in $(seq 1 8); do
+    curl -s -i -X POST "http://127.0.0.1:${PORT}/query" \
+        -H "Content-Type: application/json" \
+        --data '{"sql":"SELECT id, name FROM api_parallel_users;"}' \
+        >"${TMP_DIR}/select_${i}.txt" &
+    SELECT_PIDS+=($!)
+done
+
+for pid in "${SELECT_PIDS[@]}"; do
+    wait "$pid"
+done
+
+for i in $(seq 1 8); do
+    if ! grep -q 'HTTP/1.1 200 OK' "${TMP_DIR}/select_${i}.txt"; then
+        echo "[FAIL] api parallel select status ${i}"
+        cat "${TMP_DIR}/select_${i}.txt"
+        exit 1
+    fi
+    if ! grep -q '"row_count":3' "${TMP_DIR}/select_${i}.txt"; then
+        echo "[FAIL] api parallel select row count ${i}"
+        cat "${TMP_DIR}/select_${i}.txt"
+        exit 1
+    fi
+done
+
+echo "[PASS] api_parallel_select_smoke"

--- a/tests/concurrency/test_tokenizer_cache_threads.c
+++ b/tests/concurrency/test_tokenizer_cache_threads.c
@@ -1,0 +1,92 @@
+#include "tokenizer.h"
+#include "lock_manager.h"
+#include "utils.h"
+
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+typedef struct {
+    const char *sql;
+    int iterations;
+    int failed;
+} TokenizerWorkerState;
+
+static int assert_true(int condition, const char *message) {
+    if (!condition) {
+        fprintf(stderr, "[FAIL] %s\n", message);
+        return FAILURE;
+    }
+    return SUCCESS;
+}
+
+static void *tokenizer_worker_main(void *arg) {
+    TokenizerWorkerState *state;
+    int i;
+
+    state = (TokenizerWorkerState *)arg;
+    for (i = 0; i < state->iterations; i++) {
+        Token *tokens;
+        int token_count;
+
+        tokens = tokenizer_tokenize(state->sql, &token_count);
+        if (tokens == NULL || token_count == 0) {
+            state->failed = 1;
+            free(tokens);
+            return NULL;
+        }
+        free(tokens);
+    }
+
+    return NULL;
+}
+
+int main(void) {
+    pthread_t threads[8];
+    TokenizerWorkerState workers[8];
+    int i;
+
+    tokenizer_cleanup_cache();
+    if (init_lock_manager(LOCK_POLICY_SPLIT_RWLOCK) != SUCCESS) {
+        return EXIT_FAILURE;
+    }
+
+    for (i = 0; i < 8; i++) {
+        workers[i].sql = (i % 2 == 0)
+                             ? "SELECT name FROM threaded_cache_users WHERE id = 1;"
+                             : "INSERT INTO threaded_cache_users (name, age) VALUES ('Alice', 30);";
+        workers[i].iterations = 200;
+        workers[i].failed = 0;
+        if (pthread_create(&threads[i], NULL, tokenizer_worker_main, &workers[i]) != 0) {
+            return EXIT_FAILURE;
+        }
+    }
+
+    for (i = 0; i < 8; i++) {
+        pthread_join(threads[i], NULL);
+        if (assert_true(workers[i].failed == 0,
+                        "tokenizer threads should tokenize without failure") != SUCCESS) {
+            tokenizer_cleanup_cache();
+            return EXIT_FAILURE;
+        }
+    }
+
+    if (assert_true(tokenizer_get_cache_entry_count() > 0,
+                    "cache entry count should stay readable after threaded access") != SUCCESS ||
+        assert_true(tokenizer_get_cache_hit_count() > 0,
+                    "threaded access should record cache hits") != SUCCESS) {
+        tokenizer_cleanup_cache();
+        return EXIT_FAILURE;
+    }
+
+    tokenizer_cleanup_cache();
+    if (assert_true(tokenizer_get_cache_entry_count() == 0,
+                    "cleanup should still reset tokenizer cache after threaded access") != SUCCESS) {
+        destroy_lock_manager();
+        return EXIT_FAILURE;
+    }
+
+    destroy_lock_manager();
+    puts("[PASS] tokenizer_cache_threads");
+    return EXIT_SUCCESS;
+}

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -47,7 +47,7 @@ for binary in build/tests/db/test_tokenizer build/tests/db/test_parser \
               build/tests/db/test_storage build/tests/db/test_benchmark build/tests/db/test_table_runtime \
               build/tests/db/test_bptree build/tests/db/test_executor build/tests/db/test_db_engine_facade \
               build/tests/db/test_table_storage_loading \
-              build/tests/concurrency/test_thread_pool
+              build/tests/concurrency/test_thread_pool build/tests/concurrency/test_tokenizer_cache_threads
 do
     run_unit_test "$binary"
 done
@@ -75,6 +75,15 @@ if bash tests/api/test_api_concurrency_smoke.sh >/tmp/week8_api_concurrency_test
 else
     echo "[FAIL] api_concurrency_smoke"
     cat /tmp/week8_api_concurrency_test.log
+    FAIL=$((FAIL + 1))
+fi
+
+if bash tests/api/test_api_parallel_select_smoke.sh >/tmp/week8_api_parallel_test.log 2>&1; then
+    echo "[PASS] api_parallel_select_smoke"
+    PASS=$((PASS + 1))
+else
+    echo "[FAIL] api_parallel_select_smoke"
+    cat /tmp/week8_api_parallel_test.log
     FAIL=$((FAIL + 1))
 fi
 


### PR DESCRIPTION
## 요약
Step 6에서 tokenizer cache mutex와 DB rwlock 기반의 2차 동시성 개선을 적용합니다.

## 변경 사항
- tokenizer 전역 캐시 조회, 저장, 정리, 통계 경로에 전용 mutex 적용
- `execute_query_with_lock`가 파싱된 statement와 활성 런타임 상태를 기준으로 lock mode를 선택하도록 개선
- 이미 메모리에 적재된 같은 테이블의 `SELECT`만 read lock으로 처리하고, 적재가 필요한 `SELECT`는 write lock으로 승격해 직렬화
- 병렬 tokenizer stress test와 병렬 SELECT API smoke test 추가
- 통합 테스트 스위트에 신규 동시성 테스트 포함

## 테스트
- 권한 있는 환경에서 `make tests` 실행 (`21 passed, 0 failed`)

## 비고
- Codex 샌드박스에서는 TCP bind가 제한돼 API smoke 검증은 권한 있는 `make tests`로 확인했습니다.

Closes #13
