### PR TITLE
feat: GET /health에 워커와 큐 상태 메트릭 추가

### DIFF
--- a/src/api/api_server.c
+++ b/src/api/api_server.c
@@ -21,6 +21,10 @@
 #define API_SERVER_READ_CHUNK 4096
 #define API_SERVER_MAX_REQUEST_SIZE 65536
 
+typedef struct {
+    RequestRouterContext router_context;
+} ApiServerHandlerContext;
+
 static int api_server_append_bytes(char **buffer, size_t *length, size_t *capacity,
                                    const char *chunk, size_t chunk_length) {
     char *new_buffer;
@@ -216,7 +220,8 @@ static int api_server_send_json_error(int client_fd, int status_code,
     return status;
 }
 
-static int api_server_handle_client(int client_fd, DbEngine *engine) {
+static int api_server_handle_client(int client_fd,
+                                    const RequestRouterContext *router_context) {
     char *raw_request;
     HttpRequest request;
     char *body;
@@ -239,7 +244,7 @@ static int api_server_handle_client(int client_fd, DbEngine *engine) {
     }
     free(raw_request);
 
-    status = route_request(engine, &request, &status_code, &body);
+    status = route_request(router_context, &request, &status_code, &body);
     http_request_free(&request);
     if (status != SUCCESS) {
         free(body);
@@ -259,10 +264,10 @@ static int api_server_handle_client(int client_fd, DbEngine *engine) {
 }
 
 static void api_server_worker_handle_client(int client_fd, void *context) {
-    DbEngine *engine;
+    ApiServerHandlerContext *handler_context;
 
-    engine = (DbEngine *)context;
-    api_server_handle_client(client_fd, engine);
+    handler_context = (ApiServerHandlerContext *)context;
+    api_server_handle_client(client_fd, &handler_context->router_context);
     close(client_fd);
 }
 
@@ -304,11 +309,16 @@ static int api_server_create_socket(int port) {
 int api_server_run(DbEngine *engine, const ApiServerConfig *config) {
     int server_fd;
     ThreadPool pool;
+    ApiServerHandlerContext handler_context;
 
     if (engine == NULL || config == NULL || config->port <= 0 ||
         config->worker_count <= 0 || config->queue_capacity <= 0) {
         return FAILURE;
     }
+
+    memset(&handler_context, 0, sizeof(handler_context));
+    handler_context.router_context.engine = engine;
+    handler_context.router_context.thread_pool = &pool;
 
     server_fd = api_server_create_socket(config->port);
     if (server_fd == FAILURE) {
@@ -321,7 +331,7 @@ int api_server_run(DbEngine *engine, const ApiServerConfig *config) {
     fflush(stdout);
 
     if (thread_pool_init(&pool, config->worker_count, config->queue_capacity,
-                         api_server_worker_handle_client, engine) != SUCCESS) {
+                         api_server_worker_handle_client, &handler_context) != SUCCESS) {
         close(server_fd);
         fprintf(stderr, "Error: Failed to initialize thread pool.\n");
         return FAILURE;

--- a/src/api/request_router.c
+++ b/src/api/request_router.c
@@ -114,8 +114,16 @@ static int extract_sql_from_json(const char *body, char **out_sql) {
     return FAILURE;
 }
 
-static int handle_health_request(int *out_status_code, char **out_body) {
-    if (build_health_json_response(out_body) != SUCCESS) {
+static int handle_health_request(const RequestRouterContext *context,
+                                 int *out_status_code, char **out_body) {
+    ThreadPoolStats stats;
+
+    if (context == NULL || context->thread_pool == NULL ||
+        thread_pool_get_stats(context->thread_pool, &stats) != SUCCESS) {
+        return FAILURE;
+    }
+
+    if (build_health_json_response(&stats, out_body) != SUCCESS) {
         return FAILURE;
     }
 
@@ -123,13 +131,15 @@ static int handle_health_request(int *out_status_code, char **out_body) {
     return SUCCESS;
 }
 
-static int handle_query_request(DbEngine *engine, const HttpRequest *request,
+static int handle_query_request(const RequestRouterContext *context,
+                                const HttpRequest *request,
                                 int *out_status_code, char **out_body) {
     DbResult result;
     char *sql;
     int status;
 
-    if (engine == NULL || request == NULL || out_status_code == NULL ||
+    if (context == NULL || context->engine == NULL || request == NULL ||
+        out_status_code == NULL ||
         out_body == NULL) {
         return FAILURE;
     }
@@ -143,7 +153,7 @@ static int handle_query_request(DbEngine *engine, const HttpRequest *request,
     }
 
     db_result_init(&result);
-    status = execute_query_with_lock(engine, sql, &result);
+    status = execute_query_with_lock(context->engine, sql, &result);
     free(sql);
 
     if (status != SUCCESS) {
@@ -163,9 +173,9 @@ static int handle_query_request(DbEngine *engine, const HttpRequest *request,
     return status;
 }
 
-int route_request(DbEngine *engine, const HttpRequest *request,
+int route_request(const RequestRouterContext *context, const HttpRequest *request,
                   int *out_status_code, char **out_body) {
-    if (engine == NULL || request == NULL || out_status_code == NULL ||
+    if (context == NULL || request == NULL || out_status_code == NULL ||
         out_body == NULL) {
         return FAILURE;
     }
@@ -181,7 +191,7 @@ int route_request(DbEngine *engine, const HttpRequest *request,
             *out_status_code = 405;
             return SUCCESS;
         }
-        return handle_health_request(out_status_code, out_body);
+        return handle_health_request(context, out_status_code, out_body);
     }
 
     if (utils_equals_ignore_case(request->path, "/query")) {
@@ -193,7 +203,7 @@ int route_request(DbEngine *engine, const HttpRequest *request,
             *out_status_code = 405;
             return SUCCESS;
         }
-        return handle_query_request(engine, request, out_status_code, out_body);
+        return handle_query_request(context, request, out_status_code, out_body);
     }
 
     if (build_json_error_response(404, "Route not found.", out_body) != SUCCESS) {

--- a/src/api/request_router.h
+++ b/src/api/request_router.h
@@ -3,11 +3,17 @@
 
 #include "db_engine_facade.h"
 #include "http_parser.h"
+#include "thread_pool.h"
+
+typedef struct {
+    DbEngine *engine;
+    ThreadPool *thread_pool;
+} RequestRouterContext;
 
 /*
  * 메서드와 경로 기준으로 요청을 처리하고 JSON body와 상태 코드를 반환한다.
  */
-int route_request(DbEngine *engine, const HttpRequest *request,
+int route_request(const RequestRouterContext *context, const HttpRequest *request,
                   int *out_status_code, char **out_body);
 
 #endif

--- a/src/api/response_builder.c
+++ b/src/api/response_builder.c
@@ -223,12 +223,21 @@ int build_json_error_response(int status_code, const char *message, char **out_b
     return SUCCESS;
 }
 
-int build_health_json_response(char **out_body) {
-    if (out_body == NULL) {
+int build_health_json_response(const ThreadPoolStats *stats, char **out_body) {
+    char buffer[256];
+
+    if (stats == NULL || out_body == NULL) {
         return FAILURE;
     }
 
-    *out_body = utils_strdup("{\"status\":\"ok\"}");
+    snprintf(buffer, sizeof(buffer),
+             "{\"status\":\"ok\",\"worker_count\":%d,\"busy_workers\":%d,"
+             "\"idle_workers\":%d,\"queue_length\":%d,\"queue_capacity\":%d,"
+             "\"available_queue_slots\":%d}",
+             stats->worker_count, stats->busy_worker_count,
+             stats->idle_worker_count, stats->queue_length,
+             stats->queue_capacity, stats->available_queue_slots);
+    *out_body = utils_strdup(buffer);
     return *out_body == NULL ? FAILURE : SUCCESS;
 }
 

--- a/src/api/response_builder.h
+++ b/src/api/response_builder.h
@@ -1,6 +1,7 @@
 #ifndef RESPONSE_BUILDER_H
 #define RESPONSE_BUILDER_H
 
+#include "thread_pool.h"
 #include "executor_result.h"
 
 /*
@@ -17,7 +18,7 @@ int build_json_error_response(int status_code, const char *message, char **out_b
 /*
  * 상태 확인용 JSON body를 생성한다.
  */
-int build_health_json_response(char **out_body);
+int build_health_json_response(const ThreadPoolStats *stats, char **out_body);
 
 /*
  * JSON body를 완전한 HTTP/1.1 응답 문자열로 감싼다.

--- a/src/concurrency/thread_pool.c
+++ b/src/concurrency/thread_pool.c
@@ -17,7 +17,15 @@ static void *thread_pool_worker_main(void *arg) {
     free(arg);
 
     while (queue_pop(&pool->queue, &client_fd) == SUCCESS) {
+        pthread_mutex_lock(&pool->queue.mutex);
+        pool->active_worker_count++;
+        pthread_mutex_unlock(&pool->queue.mutex);
+
         pool->handler(client_fd, pool->handler_context);
+
+        pthread_mutex_lock(&pool->queue.mutex);
+        pool->active_worker_count--;
+        pthread_mutex_unlock(&pool->queue.mutex);
     }
 
     return NULL;
@@ -77,6 +85,22 @@ int thread_pool_submit(ThreadPool *pool, int client_fd) {
     return queue_push(&pool->queue, client_fd);
 }
 
+int thread_pool_get_stats(ThreadPool *pool, ThreadPoolStats *out_stats) {
+    if (pool == NULL || out_stats == NULL) {
+        return FAILURE;
+    }
+
+    pthread_mutex_lock(&pool->queue.mutex);
+    out_stats->worker_count = pool->worker_count;
+    out_stats->busy_worker_count = pool->active_worker_count;
+    out_stats->idle_worker_count = pool->worker_count - pool->active_worker_count;
+    out_stats->queue_length = pool->queue.count;
+    out_stats->queue_capacity = pool->queue.capacity;
+    out_stats->available_queue_slots = pool->queue.capacity - pool->queue.count;
+    pthread_mutex_unlock(&pool->queue.mutex);
+    return SUCCESS;
+}
+
 void thread_pool_shutdown(ThreadPool *pool) {
     int i;
 
@@ -94,5 +118,6 @@ void thread_pool_shutdown(ThreadPool *pool) {
     free(pool->workers);
     pool->workers = NULL;
     pool->worker_count = 0;
+    pool->active_worker_count = 0;
     queue_destroy(&pool->queue);
 }

--- a/src/concurrency/thread_pool.h
+++ b/src/concurrency/thread_pool.h
@@ -8,8 +8,18 @@
 typedef void (*ThreadPoolJobHandler)(int client_fd, void *context);
 
 typedef struct {
+    int worker_count;
+    int busy_worker_count;
+    int idle_worker_count;
+    int queue_length;
+    int queue_capacity;
+    int available_queue_slots;
+} ThreadPoolStats;
+
+typedef struct {
     pthread_t *workers;
     int worker_count;
+    int active_worker_count;
     ThreadPoolJobHandler handler;
     void *handler_context;
     JobQueue queue;
@@ -26,6 +36,11 @@ int thread_pool_init(ThreadPool *pool, int worker_count, int queue_capacity,
  * queue가 가득 차면 즉시 FAILURE를 반환한다.
  */
 int thread_pool_submit(ThreadPool *pool, int client_fd);
+
+/*
+ * thread pool과 내부 queue의 현재 상태를 스냅샷으로 반환한다.
+ */
+int thread_pool_get_stats(ThreadPool *pool, ThreadPoolStats *out_stats);
 
 /*
  * thread pool을 종료하고 모든 worker를 join한 뒤 내부 자원을 정리한다.

--- a/tests/api/test_api_smoke.sh
+++ b/tests/api/test_api_smoke.sh
@@ -36,8 +36,38 @@ if ! echo "$health_response" | grep -q 'HTTP/1.1 200 OK'; then
     exit 1
 fi
 
-if ! echo "$health_response" | grep -q '{"status":"ok"}'; then
+if ! echo "$health_response" | grep -q '"status":"ok"'; then
     echo "[FAIL] api health body"
+    echo "$health_response"
+    exit 1
+fi
+
+if ! echo "$health_response" | grep -q '"worker_count":4'; then
+    echo "[FAIL] api health worker count"
+    echo "$health_response"
+    exit 1
+fi
+
+if ! echo "$health_response" | grep -q '"queue_capacity":16'; then
+    echo "[FAIL] api health queue capacity"
+    echo "$health_response"
+    exit 1
+fi
+
+if ! echo "$health_response" | grep -q '"busy_workers":'; then
+    echo "[FAIL] api health busy workers"
+    echo "$health_response"
+    exit 1
+fi
+
+if ! echo "$health_response" | grep -q '"idle_workers":'; then
+    echo "[FAIL] api health idle workers"
+    echo "$health_response"
+    exit 1
+fi
+
+if ! echo "$health_response" | grep -q '"queue_length":'; then
+    echo "[FAIL] api health queue length"
     echo "$health_response"
     exit 1
 fi

--- a/tests/concurrency/test_thread_pool.c
+++ b/tests/concurrency/test_thread_pool.c
@@ -54,6 +54,7 @@ static int wait_for_count(HandlerState *state, int expected_count) {
 int main(void) {
     HandlerState state;
     ThreadPool pool;
+    ThreadPoolStats stats;
 
     pthread_mutex_init(&state.mutex, NULL);
     state.handled_count = 0;
@@ -61,6 +62,23 @@ int main(void) {
 
     if (assert_true(thread_pool_init(&pool, 2, 8, test_handler, &state) == SUCCESS,
                     "thread_pool_init should create workers") != SUCCESS) {
+        pthread_mutex_destroy(&state.mutex);
+        return EXIT_FAILURE;
+    }
+
+    if (assert_true(thread_pool_get_stats(&pool, &stats) == SUCCESS,
+                    "thread_pool_get_stats should succeed after initialization") != SUCCESS ||
+        assert_true(stats.worker_count == 2,
+                    "thread pool should report configured worker count") != SUCCESS ||
+        assert_true(stats.busy_worker_count == 0,
+                    "new thread pool should start with zero busy workers") != SUCCESS ||
+        assert_true(stats.idle_worker_count == 2,
+                    "new thread pool should report all workers as idle") != SUCCESS ||
+        assert_true(stats.queue_length == 0,
+                    "new thread pool should start with empty queue") != SUCCESS ||
+        assert_true(stats.queue_capacity == 8,
+                    "thread pool should report queue capacity") != SUCCESS) {
+        thread_pool_shutdown(&pool);
         pthread_mutex_destroy(&state.mutex);
         return EXIT_FAILURE;
     }
@@ -102,10 +120,36 @@ int main(void) {
     }
 
     usleep(50000);
+    if (assert_true(thread_pool_get_stats(&pool, &stats) == SUCCESS,
+                    "thread_pool_get_stats should succeed while jobs are active") != SUCCESS ||
+        assert_true(stats.worker_count == 1,
+                    "small thread pool should report one worker") != SUCCESS ||
+        assert_true(stats.busy_worker_count == 1,
+                    "active worker should be counted as busy") != SUCCESS ||
+        assert_true(stats.idle_worker_count == 0,
+                    "busy single worker leaves no idle workers") != SUCCESS) {
+        thread_pool_shutdown(&pool);
+        pthread_mutex_destroy(&state.mutex);
+        return EXIT_FAILURE;
+    }
+
     if (assert_true(thread_pool_submit(&pool, 20) == SUCCESS,
                     "second job should occupy the bounded queue") != SUCCESS ||
         assert_true(thread_pool_submit(&pool, 30) == FAILURE,
                     "third job should fail immediately when queue is full") != SUCCESS) {
+        thread_pool_shutdown(&pool);
+        pthread_mutex_destroy(&state.mutex);
+        return EXIT_FAILURE;
+    }
+
+    if (assert_true(thread_pool_get_stats(&pool, &stats) == SUCCESS,
+                    "thread_pool_get_stats should include queue pressure") != SUCCESS ||
+        assert_true(stats.queue_length == 1,
+                    "bounded queue should report one waiting job") != SUCCESS ||
+        assert_true(stats.queue_capacity == 1,
+                    "small thread pool queue capacity should be one") != SUCCESS ||
+        assert_true(stats.available_queue_slots == 0,
+                    "full queue should report zero available slots") != SUCCESS) {
         thread_pool_shutdown(&pool);
         pthread_mutex_destroy(&state.mutex);
         return EXIT_FAILURE;


### PR DESCRIPTION
## 요약
`GET /health`를 단순 생존 확인이 아니라 운영 상태 메트릭을 확인할 수 있는 엔드포인트로 확장합니다.

## 변경 사항
- `ThreadPool`에 현재 worker/queue 상태를 안전하게 읽는 `thread_pool_get_stats` 추가
- `/health` 응답에 `worker_count`, `busy_workers`, `idle_workers`, `queue_length`, `queue_capacity`, `available_queue_slots` 포함
- API 라우터가 DB 엔진뿐 아니라 thread pool 상태에도 접근할 수 있도록 컨텍스트 구조 정리
- thread pool 단위 테스트와 API smoke test를 상태 메트릭 검증까지 확장

## 테스트
- 권한 있는 환경에서 `make tests` 실행 (`21 passed, 0 failed`)

## 비고
- 샌드박스에서는 TCP bind 제약이 있어 최종 API smoke 검증은 권한 있는 `make tests`로 확인했습니다.

Closes #15
